### PR TITLE
More flexible package generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ script:
   - yarn build:prod
   - yarn test:setup
   - yarn test
+  - yarn run package
 
 after_failure:
   - yarn test:review

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ cache:
     - node_modules
     - $HOME/.electron
     - .eslintcache
+    - $HOME/.cache/electron-builder
 
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.3.2

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,0 +1,9 @@
+linux:
+  category: "GNOME;GTK;Development"
+  packageCategory: "GNOME;GTK;Development"
+  icon: "../app/static/logos"
+  target:
+    - deb
+    - rpm
+    - AppImage
+  maintainer: "GitHub, Inc <opensource+desktop@github.com>"

--- a/package.json
+++ b/package.json
@@ -126,19 +126,8 @@
     "@types/xml2js": "^0.4.0",
     "electron": "1.7.9",
     "electron-builder": "19.48.3",
-    "electron-installer-appimage": "^1.0.1",
     "electron-mocha": "^5.0.0",
     "electron-packager": "^10.1.0",
     "electron-winstaller": "2.5.2"
-  },
-  "optionalDependencies": {
-    "electron-installer-debian": "^0.7.1",
-    "electron-installer-redhat": "^0.5.0"
-  },
-  "build": {
-    "linux": {
-      "category": "Development",
-      "icon": "app/static/logos"
-    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "@types/winston": "^2.2.0",
     "@types/xml2js": "^0.4.0",
     "electron": "1.7.9",
-    "electron-builder": "19.45.5",
+    "electron-builder": "19.48.3",
     "electron-installer-appimage": "^1.0.1",
     "electron-mocha": "^5.0.0",
     "electron-packager": "^8.7.2",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "electron-builder": "19.48.3",
     "electron-installer-appimage": "^1.0.1",
     "electron-mocha": "^5.0.0",
-    "electron-packager": "^8.7.2",
+    "electron-packager": "^10.1.0",
     "electron-winstaller": "2.5.2"
   },
   "optionalDependencies": {

--- a/script/package.ts
+++ b/script/package.ts
@@ -6,7 +6,6 @@ import * as path from 'path'
 import * as electronInstaller from 'electron-winstaller'
 import { getProductName, getCompanyName } from '../app/package-info'
 import {
-  getDistRoot,
   getDistPath,
   getOSXZipPath,
   getWindowsIdentifierName,
@@ -124,83 +123,25 @@ function packageWindows() {
     })
 }
 
-function packageRedhat() {
-  const installer: ElectronInstallerRedhat = require('electron-installer-redhat')
+function packageLinux() {
+  const electronBuilder = path.resolve(
+    __dirname,
+    '..',
+    'node_modules',
+    '.bin',
+    'electron-builder'
+  )
 
-  const options = {
-    src: distPath,
-    dest: outputDir,
-    arch: 'amd64',
-  }
+  const configPath = path.resolve(__dirname, '..', 'electron-builder.yml')
 
-  return new Promise((resolve, reject) => {
-    console.log('Creating .rpm package...')
-    installer(options, err => {
-      if (err) {
-        reject(err)
-      } else {
-        resolve()
-      }
-    })
-  })
-}
+  const args = [
+    'build',
+    '--prepackaged',
+    distPath,
+    '--x64',
+    '--config',
+    configPath,
+  ]
 
-function packageDebian() {
-  const installer: ElectronInstallerDebian = require('electron-installer-debian')
-
-  const options = {
-    src: distPath,
-    dest: outputDir,
-    arch: 'amd64',
-  }
-
-  return new Promise((resolve, reject) => {
-    console.log('Creating .deb package...')
-    installer(options, err => {
-      if (err) {
-        reject(err)
-      } else {
-        resolve()
-      }
-    })
-  })
-}
-
-function packageAppImage() {
-  // Because electron-builder's CLI has some limits, we need to
-  // implement a couple of workarounds.
-  //
-  // First, it'll use `dist/make` for it's output directory, which
-  // results in this vague error when the directory doesn't exist:
-  //
-  // libburn : SORRY : Neither stdio-path nor its directory exist
-  //
-  // so let's just trash it (if already existing) and create the directory
-  const makeDir = path.join(getDistRoot(), 'make')
-  fs.removeSync(makeDir)
-  fs.mkdirSync(makeDir)
-
-  const installer: ElectronInstallerAppImage = require('electron-installer-appimage')
-
-  const options = {
-    dir: distPath,
-    targetArch: 'x64',
-  }
-
-  return installer.default(options).then(() => {
-    // Second, we need to move the relevant files from dist/make up to
-    // the installers directory so it's alongside the other packages
-    cp.execSync(`cp ${makeDir}/*.AppImage ${outputDir}`)
-  })
-}
-
-async function packageLinux(): Promise<void> {
-  try {
-    await packageRedhat()
-    await packageDebian()
-    await packageAppImage()
-    console.log(`Successfully created packages at ${outputDir}`)
-  } catch (e) {
-    console.log(`error during packaging: ${e}`)
-  }
+  cp.spawnSync(electronBuilder, args, { stdio: 'inherit' })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,14 +14,6 @@
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/7zip-bin-win/-/7zip-bin-win-2.1.1.tgz#8acfc28bb34e53a9476b46ae85a97418e6035c20"
 
-"7zip-bin@^2.2.7":
-  version "2.2.7"
-  resolved "https://registry.yarnpkg.com/7zip-bin/-/7zip-bin-2.2.7.tgz#724802b8d6bda0bf2cfe61a4b86a820efc8ece93"
-  optionalDependencies:
-    "7zip-bin-linux" "^1.1.0"
-    "7zip-bin-mac" "^1.0.1"
-    "7zip-bin-win" "^2.1.1"
-
 "7zip-bin@^2.3.4":
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/7zip-bin/-/7zip-bin-2.3.4.tgz#0861a3c99793dd794f4dd6175ec4ddfa6af8bc9d"
@@ -312,18 +304,6 @@ anymatch@^1.3.0:
     micromatch "^2.1.5"
     normalize-path "^2.0.0"
 
-app-package-builder@1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/app-package-builder/-/app-package-builder-1.3.3.tgz#252489ebd9e99fded822d01c7d6042d37aa6d844"
-  dependencies:
-    bluebird-lst "^1.0.5"
-    builder-util "^3.2.0"
-    builder-util-runtime "^2.5.0"
-    fs-extra-p "^4.4.4"
-    int64-buffer "^0.1.9"
-    js-yaml "^3.10.0"
-    rabin-bindings "~1.7.3"
-
 app-package-builder@1.5.3:
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/app-package-builder/-/app-package-builder-1.5.3.tgz#a24776370dae3b7c35e7aedfbc77b93137d2ab4c"
@@ -455,19 +435,6 @@ asar@^0.11.0:
     mkdirp "^0.5.0"
     mksnapshot "^0.3.0"
 
-asar@^0.13.0:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/asar/-/asar-0.13.1.tgz#dfc73f574a7db256b09ba62d1f0e95cd4a6cb8d3"
-  dependencies:
-    chromium-pickle-js "^0.2.0"
-    commander "^2.9.0"
-    cuint "^0.2.1"
-    glob "^6.0.4"
-    minimatch "^3.0.3"
-    mkdirp "^0.5.0"
-    mksnapshot "^0.3.0"
-    tmp "0.0.28"
-
 asar@^0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/asar/-/asar-0.14.0.tgz#998b36a26abd0e590e55d9f92cfd3fd7a6051652"
@@ -523,11 +490,7 @@ async-foreach@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/async-foreach/-/async-foreach-0.1.3.tgz#36121f845c0578172de419a97dbeb1d16ec34542"
 
-async@^1.4.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
-
-async@^2.0.0, async@^2.1.2, async@^2.1.5, async@^2.4.1, async@^2.5.0:
+async@^2.0.0, async@^2.1.2, async@^2.1.5, async@^2.4.1:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/async/-/async-2.5.0.tgz#843190fd6b7357a0b9e1c956edddd5ec8462b54d"
   dependencies:
@@ -975,7 +938,7 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bluebird-lst@^1.0.3, bluebird-lst@^1.0.4, bluebird-lst@^1.0.5:
+bluebird-lst@^1.0.4, bluebird-lst@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/bluebird-lst/-/bluebird-lst-1.0.5.tgz#bebc83026b7e92a72871a3dc599e219cbfb002a9"
   dependencies:
@@ -1156,15 +1119,6 @@ buffers@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/buffers/-/buffers-0.1.1.tgz#b24579c3bed4d6d396aeee6d9a8ae7f5482ab7bb"
 
-builder-util-runtime@2.5.0, builder-util-runtime@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-2.5.0.tgz#22373d4faab8d89e0b077630aef76538deb38476"
-  dependencies:
-    bluebird-lst "^1.0.5"
-    debug "^3.1.0"
-    fs-extra-p "^4.4.4"
-    sax "^1.2.4"
-
 builder-util-runtime@3.3.1, builder-util-runtime@^3.3.0, builder-util-runtime@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-3.3.1.tgz#d905cd5b7be7e60124a532ddd0e988e12c1bd5c3"
@@ -1173,27 +1127,6 @@ builder-util-runtime@3.3.1, builder-util-runtime@^3.3.0, builder-util-runtime@^3
     debug "^3.1.0"
     fs-extra-p "^4.4.5"
     sax "^1.2.4"
-
-builder-util@3.2.0, builder-util@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/builder-util/-/builder-util-3.2.0.tgz#08900f046c6b09c22a1f235f18644ae9eb963bc4"
-  dependencies:
-    "7zip-bin" "^2.2.7"
-    bluebird-lst "^1.0.5"
-    builder-util-runtime "^2.5.0"
-    chalk "^2.3.0"
-    debug "^3.1.0"
-    fs-extra-p "^4.4.4"
-    ini "^1.3.4"
-    is-ci "^1.0.10"
-    js-yaml "^3.10.0"
-    lazy-val "^1.0.2"
-    node-emoji "^1.8.1"
-    semver "^5.4.1"
-    source-map-support "^0.5.0"
-    stat-mode "^0.2.2"
-    temp-file "^2.0.3"
-    tunnel-agent "^0.6.0"
 
 builder-util@3.4.4, builder-util@^3.4.2, builder-util@^3.4.3:
   version "3.4.4"
@@ -1873,7 +1806,7 @@ date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
 
-debug@2.6.9, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.3, debug@^2.6.8:
+debug@2.6.9, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -2017,18 +1950,6 @@ diffie-hellman@^5.0.0:
     bn.js "^4.1.0"
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
-
-dmg-builder@2.1.5:
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-2.1.5.tgz#f1f7d68d75cfb834e793c0681c7f50ced0a3038d"
-  dependencies:
-    bluebird-lst "^1.0.5"
-    builder-util "^3.2.0"
-    debug "^3.1.0"
-    fs-extra-p "^4.4.4"
-    iconv-lite "^0.4.19"
-    js-yaml "^3.10.0"
-    parse-color "^1.0.0"
 
 dmg-builder@2.1.8:
   version "2.1.8"
@@ -2184,41 +2105,6 @@ electron-builder@19.48.3:
     update-notifier "^2.3.0"
     yargs "^10.0.3"
 
-electron-builder@^19.30.4:
-  version "19.43.3"
-  resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-19.43.3.tgz#87b1d39a50456a989b273a7effc04498dd9c4b6a"
-  dependencies:
-    "7zip-bin" "^2.2.7"
-    app-package-builder "1.3.3"
-    asar-integrity "0.2.3"
-    async-exit-hook "^2.0.1"
-    bluebird-lst "^1.0.5"
-    builder-util "3.2.0"
-    builder-util-runtime "2.5.0"
-    chalk "^2.3.0"
-    chromium-pickle-js "^0.2.0"
-    debug "^3.1.0"
-    dmg-builder "2.1.5"
-    ejs "^2.5.7"
-    electron-download-tf "4.3.4"
-    electron-osx-sign "0.4.7"
-    electron-publish "19.43.0"
-    fs-extra-p "^4.4.4"
-    hosted-git-info "^2.5.0"
-    is-ci "^1.0.10"
-    isbinaryfile "^3.0.2"
-    js-yaml "^3.10.0"
-    lazy-val "^1.0.2"
-    minimatch "^3.0.4"
-    normalize-package-data "^2.4.0"
-    plist "^2.1.0"
-    read-config-file "1.2.0"
-    sanitize-filename "^1.6.1"
-    semver "^5.4.1"
-    temp-file "^2.0.3"
-    update-notifier "^2.3.0"
-    yargs "^10.0.3"
-
 electron-chromedriver@~1.7.1:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/electron-chromedriver/-/electron-chromedriver-1.7.1.tgz#008c97976007aa4eb18491ee095e94d17ee47610"
@@ -2268,44 +2154,6 @@ electron-download@^4.0.0, electron-download@^4.1.0:
     semver "^5.3.0"
     sumchecker "^2.0.1"
 
-electron-installer-appimage@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/electron-installer-appimage/-/electron-installer-appimage-1.0.1.tgz#d7e815bec5819a2d6df50a244dd4ff3571c4d13a"
-  dependencies:
-    electron-builder "^19.30.4"
-
-electron-installer-debian@^0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/electron-installer-debian/-/electron-installer-debian-0.7.1.tgz#a09f8345861fe924e25a714d4af2e89c428b22b7"
-  dependencies:
-    asar "^0.14.0"
-    async "^2.5.0"
-    debug "^3.1.0"
-    fs-extra "^4.0.2"
-    get-folder-size "^1.0.0"
-    glob "^7.1.2"
-    lodash "^4.17.4"
-    mkdirp "^0.5.1"
-    semver "^5.4.1"
-    temp "^0.8.3"
-    word-wrap "^1.2.3"
-    yargs "^10.0.3"
-
-electron-installer-redhat@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/electron-installer-redhat/-/electron-installer-redhat-0.5.0.tgz#09699cd37bc911cf7ff99587ba77aa205e836cd2"
-  dependencies:
-    asar "^0.13.0"
-    async "^2.1.5"
-    debug "^2.6.3"
-    fs-extra "^2.1.2"
-    glob "^7.1.1"
-    lodash "^4.17.4"
-    parse-author "^2.0.0"
-    temp "^0.8.3"
-    word-wrap "^1.2.1"
-    yargs "7.0.2"
-
 electron-mocha@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/electron-mocha/-/electron-mocha-5.0.0.tgz#415b86166a6bf80125fc4106ecc2545669c284ac"
@@ -2349,17 +2197,6 @@ electron-packager@^10.1.0:
     sanitize-filename "^1.6.0"
     semver "^5.3.0"
     yargs-parser "^8.0.0"
-
-electron-publish@19.43.0:
-  version "19.43.0"
-  resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-19.43.0.tgz#3a5b8f6317a2a83faa008c26594220ffb4006664"
-  dependencies:
-    bluebird-lst "^1.0.5"
-    builder-util "^3.2.0"
-    builder-util-runtime "^2.5.0"
-    chalk "^2.3.0"
-    fs-extra-p "^4.4.4"
-    mime "^2.0.3"
 
 electron-publish@19.46.5:
   version "19.46.5"
@@ -3009,7 +2846,7 @@ fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
 
-fs-extra-p@^4.4.0, fs-extra-p@^4.4.4:
+fs-extra-p@^4.4.4:
   version "4.4.4"
   resolved "https://registry.yarnpkg.com/fs-extra-p/-/fs-extra-p-4.4.4.tgz#396ad6f914eb2954e1700fd0e18288301ed45f04"
   dependencies:
@@ -3128,13 +2965,6 @@ gaze@^1.0.0, gaze@~1.1.2:
 get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
-
-get-folder-size@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/get-folder-size/-/get-folder-size-1.0.0.tgz#134d663a0e745611b72f71c83b13f1b12f31ba29"
-  dependencies:
-    async "^1.4.2"
-    minimist "^1.2.0"
 
 get-func-name@^2.0.0:
   version "2.0.0"
@@ -3623,10 +3453,6 @@ inquirer@~3.0.6:
 int64-buffer@^0.1.10:
   version "0.1.10"
   resolved "https://registry.yarnpkg.com/int64-buffer/-/int64-buffer-0.1.10.tgz#277b228a87d95ad777d07c13832022406a473423"
-
-int64-buffer@^0.1.9:
-  version "0.1.9"
-  resolved "https://registry.yarnpkg.com/int64-buffer/-/int64-buffer-0.1.9.tgz#9e039da043b24f78b196b283e04653ef5e990f61"
 
 interpret@^1.0.0, interpret@^1.0.1:
   version "1.0.4"
@@ -4528,7 +4354,7 @@ mz@^2.6.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nan@^2.3.0, nan@^2.3.2, nan@^2.7.0:
+nan@^2.3.0, nan@^2.3.2:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.7.0.tgz#d95bf721ec877e08db276ed3fc6eb78f9083ad46"
 
@@ -5551,14 +5377,6 @@ querystring@0.2.0, querystring@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
 
-rabin-bindings@~1.7.3:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/rabin-bindings/-/rabin-bindings-1.7.3.tgz#fb6ae9dbf897988bc2504ccf4832ee4f0546d32a"
-  dependencies:
-    bindings "^1.3.0"
-    nan "^2.7.0"
-    prebuild-install "^2.3.0"
-
 rabin-bindings@~1.7.4:
   version "1.7.4"
   resolved "https://registry.yarnpkg.com/rabin-bindings/-/rabin-bindings-1.7.4.tgz#174581d3b9a3c1b09ece75dc21f1b4ae0dd79974"
@@ -5605,20 +5423,6 @@ rc@^1.0.1, rc@^1.1.2, rc@^1.1.6, rc@^1.1.7, rc@^1.2.1:
 rcedit@^0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/rcedit/-/rcedit-0.9.0.tgz#3910df57345399e2b0325f4a519007f89e55ef1c"
-
-read-config-file@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/read-config-file/-/read-config-file-1.2.0.tgz#1fd7dc8ccdad838cac9f686182625290fc94f456"
-  dependencies:
-    ajv "^5.2.3"
-    ajv-keywords "^2.1.0"
-    bluebird-lst "^1.0.4"
-    dotenv "^4.0.0"
-    dotenv-expand "^4.0.1"
-    fs-extra-p "^4.4.4"
-    js-yaml "^3.10.0"
-    json5 "^0.5.1"
-    lazy-val "^1.0.2"
 
 read-config-file@1.2.1:
   version "1.2.1"
@@ -6574,15 +6378,6 @@ tar@^2.0.0, tar@^2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
-temp-file@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/temp-file/-/temp-file-2.0.3.tgz#0de2540629fc77a6406ca56f50214d1f224947ac"
-  dependencies:
-    async-exit-hook "^2.0.1"
-    bluebird-lst "^1.0.3"
-    fs-extra-p "^4.4.0"
-    lazy-val "^1.0.2"
-
 temp-file@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/temp-file/-/temp-file-3.0.0.tgz#1e9eca9c411a41564f5746bc2774c39080021db0"
@@ -7258,10 +7053,6 @@ window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
 
-word-wrap@^1.2.1, word-wrap@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
-
 wordwrap@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"
@@ -7394,24 +7185,6 @@ yargs-parser@^8.0.0:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-8.0.0.tgz#21d476330e5a82279a4b881345bf066102e219c6"
   dependencies:
     camelcase "^4.1.0"
-
-yargs@7.0.2:
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-7.0.2.tgz#115b97df1321823e8b8648e8968c782521221f67"
-  dependencies:
-    camelcase "^3.0.0"
-    cliui "^3.2.0"
-    decamelize "^1.1.1"
-    get-caller-file "^1.0.1"
-    os-locale "^1.4.0"
-    read-pkg-up "^1.0.1"
-    require-directory "^2.1.1"
-    require-main-filename "^1.0.1"
-    set-blocking "^2.0.0"
-    string-width "^1.0.2"
-    which-module "^1.0.0"
-    y18n "^3.2.1"
-    yargs-parser "^5.0.0"
 
 yargs@^10.0.3:
   version "10.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,6 +22,14 @@
     "7zip-bin-mac" "^1.0.1"
     "7zip-bin-win" "^2.1.1"
 
+"7zip-bin@^2.3.4":
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/7zip-bin/-/7zip-bin-2.3.4.tgz#0861a3c99793dd794f4dd6175ec4ddfa6af8bc9d"
+  optionalDependencies:
+    "7zip-bin-linux" "^1.1.0"
+    "7zip-bin-mac" "^1.0.1"
+    "7zip-bin-win" "^2.1.1"
+
 "@types/byline@^4.2.31":
   version "4.2.31"
   resolved "https://registry.yarnpkg.com/@types/byline/-/byline-4.2.31.tgz#0e61fcb9c03e047d21c4496554c7116297ab60cd"
@@ -203,7 +211,7 @@ ajv-keywords@^1.1.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
 
-ajv-keywords@^2.0.0, ajv-keywords@^2.1.0:
+ajv-keywords@^2.0.0, ajv-keywords@^2.1.0, ajv-keywords@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
 
@@ -226,6 +234,15 @@ ajv@^5.0.0, ajv@^5.1.0, ajv@^5.1.5, ajv@^5.2.3:
 ajv@^5.3.0:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.4.0.tgz#32d1cf08dbc80c432f426f12e10b2511f6b46474"
+  dependencies:
+    co "^4.6.0"
+    fast-deep-equal "^1.0.0"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.3.0"
+
+ajv@^5.5.1:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.1.tgz#b38bb8876d9e86bee994956a04e721e88b248eb2"
   dependencies:
     co "^4.6.0"
     fast-deep-equal "^1.0.0"
@@ -303,16 +320,16 @@ app-package-builder@1.3.3:
     js-yaml "^3.10.0"
     rabin-bindings "~1.7.3"
 
-app-package-builder@1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/app-package-builder/-/app-package-builder-1.5.0.tgz#3263598b07ac577b3df2205171a449f2dd5f30ca"
+app-package-builder@1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/app-package-builder/-/app-package-builder-1.5.3.tgz#a24776370dae3b7c35e7aedfbc77b93137d2ab4c"
   dependencies:
     bluebird-lst "^1.0.5"
-    builder-util "^3.2.1"
-    builder-util-runtime "^3.1.0"
+    builder-util "^3.4.3"
+    builder-util-runtime "^3.3.0"
     fs-extra-p "^4.4.4"
-    int64-buffer "^0.1.9"
-    rabin-bindings "~1.7.3"
+    int64-buffer "^0.1.10"
+    rabin-bindings "~1.7.4"
 
 aproba@^1.0.3:
   version "1.2.0"
@@ -1144,13 +1161,13 @@ builder-util-runtime@2.5.0, builder-util-runtime@^2.5.0:
     fs-extra-p "^4.4.4"
     sax "^1.2.4"
 
-builder-util-runtime@3.2.0, builder-util-runtime@^3.1.0, builder-util-runtime@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-3.2.0.tgz#b946032b61c940533fa5e8f05afc550b8e56c94c"
+builder-util-runtime@3.3.1, builder-util-runtime@^3.3.0, builder-util-runtime@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-3.3.1.tgz#d905cd5b7be7e60124a532ddd0e988e12c1bd5c3"
   dependencies:
     bluebird-lst "^1.0.5"
     debug "^3.1.0"
-    fs-extra-p "^4.4.4"
+    fs-extra-p "^4.4.5"
     sax "^1.2.4"
 
 builder-util@3.2.0, builder-util@^3.2.0:
@@ -1174,46 +1191,25 @@ builder-util@3.2.0, builder-util@^3.2.0:
     temp-file "^2.0.3"
     tunnel-agent "^0.6.0"
 
-builder-util@3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/builder-util/-/builder-util-3.2.2.tgz#9660f74f168f6d4e175ca3c25c8e0d0ed7ff965c"
+builder-util@3.4.4, builder-util@^3.4.2, builder-util@^3.4.3:
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/builder-util/-/builder-util-3.4.4.tgz#cab30f37c1ee4fb23d33b20ac71e76e3c8451d28"
   dependencies:
-    "7zip-bin" "^2.2.7"
+    "7zip-bin" "^2.3.4"
     bluebird-lst "^1.0.5"
-    builder-util-runtime "^3.2.0"
+    builder-util-runtime "^3.3.1"
     chalk "^2.3.0"
     debug "^3.1.0"
-    fs-extra-p "^4.4.4"
-    ini "^1.3.4"
-    is-ci "^1.0.10"
-    js-yaml "^3.10.0"
-    lazy-val "^1.0.2"
-    node-emoji "^1.8.1"
-    semver "^5.4.1"
-    source-map-support "^0.5.0"
-    stat-mode "^0.2.2"
-    temp-file "^2.0.3"
-    tunnel-agent "^0.6.0"
-
-builder-util@^3.2.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/builder-util/-/builder-util-3.4.1.tgz#b9f079ff4c279699ca52f42930bab1c19ff62517"
-  dependencies:
-    "7zip-bin" "^2.2.7"
-    bluebird-lst "^1.0.5"
-    builder-util-runtime "^3.2.0"
-    chalk "^2.3.0"
-    debug "^3.1.0"
-    fs-extra-p "^4.4.4"
+    fs-extra-p "^4.4.5"
     ini "^1.3.5"
     is-ci "^1.0.10"
     js-yaml "^3.10.0"
-    lazy-val "^1.0.2"
+    lazy-val "^1.0.3"
     node-emoji "^1.8.1"
     semver "^5.4.1"
     source-map-support "^0.5.0"
     stat-mode "^0.2.2"
-    temp-file "^2.1.1"
+    temp-file "^3.0.0"
     tunnel-agent "^0.6.0"
 
 builtin-modules@^1.0.0, builtin-modules@^1.1.1:
@@ -2030,12 +2026,12 @@ dmg-builder@2.1.5:
     js-yaml "^3.10.0"
     parse-color "^1.0.0"
 
-dmg-builder@2.1.6:
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-2.1.6.tgz#a37f0c8360794a7051a30a571582968cb1e3ce30"
+dmg-builder@2.1.8:
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-2.1.8.tgz#80455063144a4e7446d55acae6e01bafc4137f7d"
   dependencies:
     bluebird-lst "^1.0.5"
-    builder-util "^3.2.1"
+    builder-util "^3.4.2"
     debug "^3.1.0"
     fs-extra-p "^4.4.4"
     iconv-lite "^0.4.19"
@@ -2135,38 +2131,52 @@ ejs@^2.5.7, ejs@~2.5.6:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.5.7.tgz#cc872c168880ae3c7189762fd5ffc00896c9518a"
 
-electron-builder@19.45.5:
-  version "19.45.5"
-  resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-19.45.5.tgz#67a949d71cd2e947efd333fc9a933bd36c552cc6"
+electron-builder-lib@19.48.3:
+  version "19.48.3"
+  resolved "https://registry.yarnpkg.com/electron-builder-lib/-/electron-builder-lib-19.48.3.tgz#2d04948f1f0a98dc0edc4578b591122bde7440f6"
   dependencies:
-    "7zip-bin" "^2.2.7"
-    app-package-builder "1.5.0"
+    "7zip-bin" "^2.3.4"
+    app-package-builder "1.5.3"
     asar-integrity "0.2.3"
     async-exit-hook "^2.0.1"
     bluebird-lst "^1.0.5"
-    builder-util "3.2.2"
-    builder-util-runtime "3.2.0"
-    chalk "^2.3.0"
+    builder-util "3.4.4"
+    builder-util-runtime "3.3.1"
     chromium-pickle-js "^0.2.0"
     debug "^3.1.0"
-    dmg-builder "2.1.6"
+    dmg-builder "2.1.8"
     ejs "^2.5.7"
-    electron-download-tf "4.3.4"
     electron-osx-sign "0.4.7"
-    electron-publish "19.45.0"
-    fs-extra-p "^4.4.4"
+    electron-publish "19.46.5"
+    fs-extra-p "^4.4.5"
     hosted-git-info "^2.5.0"
     is-ci "^1.0.10"
     isbinaryfile "^3.0.2"
     js-yaml "^3.10.0"
-    lazy-val "^1.0.2"
+    lazy-val "^1.0.3"
     minimatch "^3.0.4"
     normalize-package-data "^2.4.0"
     plist "^2.1.0"
-    read-config-file "1.2.0"
+    read-config-file "1.2.1"
     sanitize-filename "^1.6.1"
     semver "^5.4.1"
-    temp-file "^2.0.3"
+    temp-file "^3.0.0"
+
+electron-builder@19.48.3:
+  version "19.48.3"
+  resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-19.48.3.tgz#5bfa39c73aa8c17a1ef1775af70b0a8b20b8011f"
+  dependencies:
+    bluebird-lst "^1.0.5"
+    builder-util "3.4.4"
+    builder-util-runtime "3.3.1"
+    chalk "^2.3.0"
+    electron-builder-lib "19.48.3"
+    electron-download-tf "4.3.4"
+    fs-extra-p "^4.4.5"
+    is-ci "^1.0.10"
+    lazy-val "^1.0.3"
+    read-config-file "1.2.1"
+    sanitize-filename "^1.6.1"
     update-notifier "^2.3.0"
     yargs "^10.0.3"
 
@@ -2343,13 +2353,13 @@ electron-publish@19.43.0:
     fs-extra-p "^4.4.4"
     mime "^2.0.3"
 
-electron-publish@19.45.0:
-  version "19.45.0"
-  resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-19.45.0.tgz#7cdcf4f54dd821bffaf4dcc59b21223cfbd8ac4c"
+electron-publish@19.46.5:
+  version "19.46.5"
+  resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-19.46.5.tgz#eb545af247edc78297a9ace6ebb2bad7c0fcc2a4"
   dependencies:
     bluebird-lst "^1.0.5"
-    builder-util "^3.2.1"
-    builder-util-runtime "^3.1.0"
+    builder-util "^3.4.2"
+    builder-util-runtime "^3.3.0"
     chalk "^2.3.0"
     fs-extra-p "^4.4.4"
     mime "^2.0.3"
@@ -2998,6 +3008,13 @@ fs-extra-p@^4.4.0, fs-extra-p@^4.4.4:
     bluebird-lst "^1.0.4"
     fs-extra "^4.0.2"
 
+fs-extra-p@^4.4.5:
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/fs-extra-p/-/fs-extra-p-4.4.5.tgz#90875f2615b53d0085b562e15d579281b9d454c2"
+  dependencies:
+    bluebird-lst "^1.0.5"
+    fs-extra "^4.0.3"
+
 fs-extra@0.26.7, fs-extra@^0.26.7:
   version "0.26.7"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-0.26.7.tgz#9ae1fdd94897798edab76d0918cf42d0c3184fa9"
@@ -3036,6 +3053,14 @@ fs-extra@^3.0.0:
 fs-extra@^4.0.1, fs-extra@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.2.tgz#f91704c53d1b461f893452b0c307d9997647ab6b"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
+fs-extra@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
@@ -3595,6 +3620,10 @@ inquirer@~3.0.6:
     strip-ansi "^3.0.0"
     through "^2.3.6"
 
+int64-buffer@^0.1.10:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/int64-buffer/-/int64-buffer-0.1.10.tgz#277b228a87d95ad777d07c13832022406a473423"
+
 int64-buffer@^0.1.9:
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/int64-buffer/-/int64-buffer-0.1.9.tgz#9e039da043b24f78b196b283e04653ef5e990f61"
@@ -4076,6 +4105,10 @@ lazy-val@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/lazy-val/-/lazy-val-1.0.2.tgz#d9b07fb1fce54cbc99b3c611de431b83249369b6"
 
+lazy-val@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/lazy-val/-/lazy-val-1.0.3.tgz#bb97b200ef00801d94c317e29dc6ed39e31c5edc"
+
 lazystream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lazystream/-/lazystream-1.0.0.tgz#f6995fe0f820392f61396be89462407bb77168e4"
@@ -4492,6 +4525,10 @@ mute-stream@0.0.7:
 nan@^2.3.0, nan@^2.3.2, nan@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.7.0.tgz#d95bf721ec877e08db276ed3fc6eb78f9083ad46"
+
+nan@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.8.0.tgz#ed715f3fe9de02b57a5e6252d90a96675e1f085a"
 
 nanomatch@^1.2.5:
   version "1.2.5"
@@ -5497,6 +5534,14 @@ rabin-bindings@~1.7.3:
     nan "^2.7.0"
     prebuild-install "^2.3.0"
 
+rabin-bindings@~1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/rabin-bindings/-/rabin-bindings-1.7.4.tgz#174581d3b9a3c1b09ece75dc21f1b4ae0dd79974"
+  dependencies:
+    bindings "^1.3.0"
+    nan "^2.8.0"
+    prebuild-install "^2.3.0"
+
 randomatic@^1.1.3:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.7.tgz#c7abe9cc8b87c0baa876b19fde83fd464797e38c"
@@ -5543,6 +5588,20 @@ read-config-file@1.2.0:
     ajv "^5.2.3"
     ajv-keywords "^2.1.0"
     bluebird-lst "^1.0.4"
+    dotenv "^4.0.0"
+    dotenv-expand "^4.0.1"
+    fs-extra-p "^4.4.4"
+    js-yaml "^3.10.0"
+    json5 "^0.5.1"
+    lazy-val "^1.0.2"
+
+read-config-file@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/read-config-file/-/read-config-file-1.2.1.tgz#f889ea5c13372319433f5df09d7a9742c72d0b25"
+  dependencies:
+    ajv "^5.5.1"
+    ajv-keywords "^2.1.1"
+    bluebird-lst "^1.0.5"
     dotenv "^4.0.0"
     dotenv-expand "^4.0.1"
     fs-extra-p "^4.4.4"
@@ -6503,9 +6562,9 @@ temp-file@^2.0.3:
     fs-extra-p "^4.4.0"
     lazy-val "^1.0.2"
 
-temp-file@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/temp-file/-/temp-file-2.1.1.tgz#7c2db304595007461b16a06e3625639cbf69a91d"
+temp-file@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/temp-file/-/temp-file-3.0.0.tgz#1e9eca9c411a41564f5746bc2774c39080021db0"
   dependencies:
     async-exit-hook "^2.0.1"
     bluebird-lst "^1.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -301,6 +301,10 @@ ansi-styles@^3.1.0:
   dependencies:
     color-convert "^1.9.0"
 
+any-promise@^1.0.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
+
 anymatch@^1.3.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-1.3.2.tgz#553dcb8f91e3c889845dfdba34c77721b90b9d7a"
@@ -452,8 +456,8 @@ asar@^0.11.0:
     mksnapshot "^0.3.0"
 
 asar@^0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/asar/-/asar-0.13.0.tgz#df33dd9d01bff842464d0d9f095740d4a62afb14"
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/asar/-/asar-0.13.1.tgz#dfc73f574a7db256b09ba62d1f0e95cd4a6cb8d3"
   dependencies:
     chromium-pickle-js "^0.2.0"
     commander "^2.9.0"
@@ -2323,24 +2327,28 @@ electron-osx-sign@0.4.7, electron-osx-sign@^0.4.1:
     minimist "^1.2.0"
     plist "^2.1.0"
 
-electron-packager@^8.7.2:
-  version "8.7.2"
-  resolved "https://registry.yarnpkg.com/electron-packager/-/electron-packager-8.7.2.tgz#457d3bf24bc9607c06ad4b1eb6daa4accadc2108"
+electron-packager@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/electron-packager/-/electron-packager-10.1.0.tgz#b7ce2940e949dbde0dac8fb20afcb9d3d9819f94"
   dependencies:
-    asar "^0.13.0"
-    debug "^2.2.0"
+    asar "^0.14.0"
+    debug "^3.0.0"
     electron-download "^4.0.0"
     electron-osx-sign "^0.4.1"
     extract-zip "^1.0.3"
-    fs-extra "^3.0.0"
+    fs-extra "^4.0.0"
     get-package-info "^1.0.0"
-    minimist "^1.1.1"
+    mz "^2.6.0"
+    nodeify "^1.0.1"
+    parse-author "^2.0.0"
+    pify "^3.0.0"
     plist "^2.0.0"
+    pruner "^0.0.7"
     rcedit "^0.9.0"
     resolve "^1.1.6"
-    run-series "^1.1.1"
     sanitize-filename "^1.6.0"
     semver "^5.3.0"
+    yargs-parser "^8.0.0"
 
 electron-publish@19.43.0:
   version "19.43.0"
@@ -3042,25 +3050,17 @@ fs-extra@^2.0.0, fs-extra@^2.1.2:
     graceful-fs "^4.1.2"
     jsonfile "^2.1.0"
 
-fs-extra@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-3.0.1.tgz#3794f378c58b342ea7dbbb23095109c4b3b62291"
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^3.0.0"
-    universalify "^0.1.0"
-
-fs-extra@^4.0.1, fs-extra@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.2.tgz#f91704c53d1b461f893452b0c307d9997647ab6b"
+fs-extra@^4.0.0, fs-extra@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
+fs-extra@^4.0.1, fs-extra@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.2.tgz#f91704c53d1b461f893452b0c307d9997647ab6b"
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
@@ -3827,6 +3827,10 @@ is-promise@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
 
+is-promise@~1, is-promise@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-1.0.1.tgz#31573761c057e33c2e91aab9e96da08cefbe76e5"
+
 is-redirect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
@@ -4009,12 +4013,6 @@ json5@^0.5.0, json5@^0.5.1:
 jsonfile@^2.1.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
-  optionalDependencies:
-    graceful-fs "^4.1.6"
-
-jsonfile@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-3.0.1.tgz#a5ecc6f65f53f662c4415c7675a0331d0992ec66"
   optionalDependencies:
     graceful-fs "^4.1.6"
 
@@ -4453,7 +4451,7 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
+minimist@^1.1.0, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -4521,6 +4519,14 @@ ms@2.0.0:
 mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
+
+mz@^2.6.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/mz/-/mz-2.7.0.tgz#95008057a56cafadc2bc63dde7f9ff6955948e32"
+  dependencies:
+    any-promise "^1.0.0"
+    object-assign "^4.0.1"
+    thenify-all "^1.0.0"
 
 nan@^2.3.0, nan@^2.3.2, nan@^2.7.0:
   version "2.7.0"
@@ -4686,6 +4692,13 @@ node-sass@^4.5.2:
     request "^2.79.0"
     sass-graph "^2.1.1"
     stdout-stream "^1.4.0"
+
+nodeify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/nodeify/-/nodeify-1.0.1.tgz#64ab69a7bdbaf03ce107b4f0335c87c0b9e91b1d"
+  dependencies:
+    is-promise "~1.0.0"
+    promise "~1.3.0"
 
 noop-logger@^0.1.1:
   version "0.1.1"
@@ -5451,6 +5464,12 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+promise@~1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-1.3.0.tgz#e5cc9a4c8278e4664ffedc01c7da84842b040175"
+  dependencies:
+    is-promise "~1"
+
 prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
@@ -5469,6 +5488,12 @@ proxy-addr@~2.0.2:
 prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
+
+pruner@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/pruner/-/pruner-0.0.7.tgz#345fbcb3e80701163a1d7adf56bac229a5a1e4c1"
+  dependencies:
+    fs-extra "^4.0.0"
 
 pseudomap@^1.0.2:
   version "1.0.2"
@@ -5944,10 +5969,6 @@ run-async@^2.2.0:
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
   dependencies:
     is-promise "^2.1.0"
-
-run-series@^1.1.1:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/run-series/-/run-series-1.1.4.tgz#89a73ddc5e75c9ef8ab6320c0a1600d6a41179b9"
 
 rx-lite-aggregates@^4.0.8:
   version "4.0.8"
@@ -6587,6 +6608,18 @@ term-size@^1.2.0:
 text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+
+thenify-all@^1.0.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/thenify-all/-/thenify-all-1.6.0.tgz#1a1918d402d8fc3f98fbf234db0bcc8cc10e9726"
+  dependencies:
+    thenify ">= 3.1.0 < 4"
+
+"thenify@>= 3.1.0 < 4":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/thenify/-/thenify-3.3.0.tgz#e69e38a1babe969b0108207978b9f62b88604839"
+  dependencies:
+    any-promise "^1.0.0"
 
 throttleit@0.0.2:
   version "0.0.2"


### PR DESCRIPTION
The `electron-installer-*` packages are nice helpers, but it'd be really nice if we could just use `electron-builder` directly, with our prebuilt output. Let's see what this feels like.

 - [x] confirm we can still generate packages
 - [x] experiment with [CLI interface](https://www.electron.build/cli) to generate AppImage instead
 - [ ] ???