### PR TITLE
Update electron-devtools-installer

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -56,7 +56,7 @@
   "devDependencies": {
     "devtron": "^1.4.0",
     "electron-debug": "^1.1.0",
-    "electron-devtools-installer": "^2.1.0",
+    "electron-devtools-installer": "^2.2.1",
     "react-addons-perf": "15.4.2",
     "react-addons-test-utils": "^15.6.2",
     "style-loader": "^0.13.2",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -292,9 +292,9 @@ electron-debug@^1.1.0:
     electron-is-dev "^0.3.0"
     electron-localshortcut "^3.0.0"
 
-electron-devtools-installer@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/electron-devtools-installer/-/electron-devtools-installer-2.2.0.tgz#9813e6811afcd69ddca3cae5416db72ea7ecfb6a"
+electron-devtools-installer@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/electron-devtools-installer/-/electron-devtools-installer-2.2.1.tgz#0beb73ccbf65cbc4d09e706cebda638f839b8c55"
   dependencies:
     "7zip" "0.0.6"
     cross-unzip "0.0.2"


### PR DESCRIPTION
Removes warning and fixes issues with permissions in development mode.
Fixes #5