### PR TITLE
upgrade electron-builder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ addons:
 branches:
   only:
     - master
+    - linux
     - /^__release-.*/
 
 language: node_js

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "@types/winston": "^2.2.0",
     "@types/xml2js": "^0.4.0",
     "electron": "2.0.5",
-    "electron-builder": "20.19.2",
+    "electron-builder": "20.26.1",
     "electron-mocha": "^6.0.1",
     "electron-packager": "^12.0.0",
     "electron-winstaller": "2.5.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -538,7 +538,7 @@ ajv@^6.4.0:
     json-schema-traverse "^0.3.0"
     uri-js "^3.0.2"
 
-ajv@^6.5.1:
+ajv@^6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.5.2.tgz#678495f9b82f7cca6be248dd92f59bff5e1f4360"
   dependencies:
@@ -604,13 +604,40 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-app-builder-bin@1.10.3:
-  version "1.10.3"
-  resolved "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-1.10.3.tgz#ab4d7b1a3bf4005dea16bf0b184077b3136f8ae9"
+app-builder-bin@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-2.0.0.tgz#bda985bee14370b254841a9982753b8f383415c5"
 
-app-builder-bin@1.11.1:
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-1.11.1.tgz#33741167f2873cf76805c9557b62caac8ede017b"
+app-builder-lib@20.26.1, app-builder-lib@~20.26.0:
+  version "20.26.1"
+  resolved "https://registry.yarnpkg.com/app-builder-lib/-/app-builder-lib-20.26.1.tgz#5165875e23436244a287594676235a25f8d15bd9"
+  dependencies:
+    "7zip-bin" "~4.0.2"
+    app-builder-bin "2.0.0"
+    async-exit-hook "^2.0.1"
+    bluebird-lst "^1.0.5"
+    builder-util "5.20.1"
+    builder-util-runtime "4.4.1"
+    chromium-pickle-js "^0.2.0"
+    debug "^3.1.0"
+    ejs "^2.6.1"
+    electron-osx-sign "0.4.10"
+    electron-publish "20.26.0"
+    env-paths "^1.0.0"
+    fs-extra-p "^4.6.1"
+    hosted-git-info "^2.7.1"
+    is-ci "^1.1.0"
+    isbinaryfile "^3.0.2"
+    js-yaml "^3.12.0"
+    lazy-val "^1.0.3"
+    minimatch "^3.0.4"
+    normalize-package-data "^2.4.0"
+    plist "^3.0.1"
+    read-config-file "3.1.0"
+    sanitize-filename "^1.6.1"
+    semver "^5.5.0"
+    sumchecker "^2.0.2"
+    temp-file "^3.1.3"
 
 aproba@^1.0.3, aproba@^1.1.1:
   version "1.2.0"
@@ -1447,42 +1474,23 @@ buffers@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/buffers/-/buffers-0.1.1.tgz#b24579c3bed4d6d396aeee6d9a8ae7f5482ab7bb"
 
-builder-util-runtime@4.4.0, builder-util-runtime@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-4.4.0.tgz#1f486819df12a04abfa128fe082e7c54edda0ef7"
+builder-util-runtime@4.4.1, builder-util-runtime@^4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-4.4.1.tgz#2770d03241e51fde46acacc7ed3ed8a9f45f02cb"
   dependencies:
     bluebird-lst "^1.0.5"
     debug "^3.1.0"
     fs-extra-p "^4.6.1"
     sax "^1.2.4"
 
-builder-util@5.13.2:
-  version "5.13.2"
-  resolved "https://registry.yarnpkg.com/builder-util/-/builder-util-5.13.2.tgz#58b43b5b2c4acdeb9d4994b47152acdb111683ea"
+builder-util@5.20.1, builder-util@~5.20.0:
+  version "5.20.1"
+  resolved "https://registry.yarnpkg.com/builder-util/-/builder-util-5.20.1.tgz#64544def24a9fbbdc77ac0c027661bb3dbb520a2"
   dependencies:
     "7zip-bin" "~4.0.2"
-    app-builder-bin "1.10.3"
+    app-builder-bin "2.0.0"
     bluebird-lst "^1.0.5"
-    builder-util-runtime "^4.4.0"
-    chalk "^2.4.1"
-    debug "^3.1.0"
-    fs-extra-p "^4.6.1"
-    is-ci "^1.1.0"
-    js-yaml "^3.12.0"
-    lazy-val "^1.0.3"
-    semver "^5.5.0"
-    source-map-support "^0.5.6"
-    stat-mode "^0.2.2"
-    temp-file "^3.1.3"
-
-builder-util@^5.13.1, builder-util@^5.13.2:
-  version "5.15.0"
-  resolved "https://registry.yarnpkg.com/builder-util/-/builder-util-5.15.0.tgz#e8381a67bfd1de17e45ea9f1dec26317169a30f3"
-  dependencies:
-    "7zip-bin" "~4.0.2"
-    app-builder-bin "1.11.1"
-    bluebird-lst "^1.0.5"
-    builder-util-runtime "^4.4.0"
+    builder-util-runtime "^4.4.1"
     chalk "^2.4.1"
     debug "^3.1.0"
     fs-extra-p "^4.6.1"
@@ -2392,13 +2400,13 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
-dmg-builder@4.11.6:
-  version "4.11.6"
-  resolved "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-4.11.6.tgz#ea686a487376b9288ffb306e0db6b6c8a9b7ed86"
+dmg-builder@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-5.1.0.tgz#fc8528ab3b053e6e4d42087ed63f613894466271"
   dependencies:
+    app-builder-lib "~20.26.0"
     bluebird-lst "^1.0.5"
-    builder-util "^5.13.2"
-    electron-builder-lib "~20.19.1"
+    builder-util "~5.20.0"
     fs-extra-p "^4.6.1"
     iconv-lite "^0.4.23"
     js-yaml "^3.12.0"
@@ -2520,52 +2528,20 @@ ejs@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.6.1.tgz#498ec0d495655abc6f23cd61868d926464071aa0"
 
-electron-builder-lib@20.19.2, electron-builder-lib@~20.19.1:
-  version "20.19.2"
-  resolved "https://registry.yarnpkg.com/electron-builder-lib/-/electron-builder-lib-20.19.2.tgz#1ad1053f8e02c87a5f949fec575fe55a8dff4b8b"
+electron-builder@20.26.1:
+  version "20.26.1"
+  resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-20.26.1.tgz#a8a99fc6484547b9ee62cee79adeea665707523c"
   dependencies:
-    "7zip-bin" "~4.0.2"
-    app-builder-bin "1.10.3"
-    async-exit-hook "^2.0.1"
+    app-builder-lib "20.26.1"
     bluebird-lst "^1.0.5"
-    builder-util "5.13.2"
-    builder-util-runtime "4.4.0"
-    chromium-pickle-js "^0.2.0"
-    debug "^3.1.0"
-    ejs "^2.6.1"
-    electron-osx-sign "0.4.10"
-    electron-publish "20.19.0"
-    env-paths "^1.0.0"
-    fs-extra-p "^4.6.1"
-    hosted-git-info "^2.6.1"
-    is-ci "^1.1.0"
-    isbinaryfile "^3.0.2"
-    js-yaml "^3.12.0"
-    lazy-val "^1.0.3"
-    minimatch "^3.0.4"
-    normalize-package-data "^2.4.0"
-    plist "^3.0.1"
-    read-config-file "3.0.2"
-    sanitize-filename "^1.6.1"
-    semver "^5.5.0"
-    stream-json "^1.1.0"
-    sumchecker "^2.0.2"
-    temp-file "^3.1.3"
-
-electron-builder@20.19.2:
-  version "20.19.2"
-  resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-20.19.2.tgz#0c782ddbefa17192278963ab58c461b3a13dc99c"
-  dependencies:
-    bluebird-lst "^1.0.5"
-    builder-util "5.13.2"
-    builder-util-runtime "4.4.0"
+    builder-util "5.20.1"
+    builder-util-runtime "4.4.1"
     chalk "^2.4.1"
-    dmg-builder "4.11.6"
-    electron-builder-lib "20.19.2"
+    dmg-builder "5.1.0"
     fs-extra-p "^4.6.1"
     is-ci "^1.1.0"
     lazy-val "^1.0.3"
-    read-config-file "3.0.2"
+    read-config-file "3.1.0"
     sanitize-filename "^1.6.1"
     update-notifier "^2.5.0"
     yargs "^12.0.1"
@@ -2659,13 +2635,13 @@ electron-packager@^12.0.0:
     semver "^5.3.0"
     yargs-parser "^10.0.0"
 
-electron-publish@20.19.0:
-  version "20.19.0"
-  resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-20.19.0.tgz#5d272ba4d4a8b54da8770505da4bcbf460662394"
+electron-publish@20.26.0:
+  version "20.26.0"
+  resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-20.26.0.tgz#406f9ccc10d09925492497cb4bee869f664a5945"
   dependencies:
     bluebird-lst "^1.0.5"
-    builder-util "^5.13.1"
-    builder-util-runtime "^4.4.0"
+    builder-util "~5.20.0"
+    builder-util-runtime "^4.4.1"
     chalk "^2.4.1"
     fs-extra-p "^4.6.1"
     lazy-val "^1.0.3"
@@ -3777,7 +3753,7 @@ hosted-git-info@^2.1.4:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
 
-hosted-git-info@^2.6.1:
+hosted-git-info@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
 
@@ -6104,11 +6080,11 @@ rcedit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/rcedit/-/rcedit-1.0.0.tgz#43309ecbc8814f3582fca6b751748cfad66a16a2"
 
-read-config-file@3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/read-config-file/-/read-config-file-3.0.2.tgz#3866666a8772d350cfbfe9a4b26187df34883c56"
+read-config-file@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/read-config-file/-/read-config-file-3.1.0.tgz#d433283c76f32204d6995542e4a04723db9e8308"
   dependencies:
-    ajv "^6.5.1"
+    ajv "^6.5.2"
     ajv-keywords "^3.2.0"
     bluebird-lst "^1.0.5"
     dotenv "^6.0.0"
@@ -6980,10 +6956,6 @@ stream-browserify@^2.0.1:
     inherits "~2.0.1"
     readable-stream "^2.0.2"
 
-stream-chain@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/stream-chain/-/stream-chain-2.0.3.tgz#9155237a719c8bb2de883c2d1af66d1546f910c9"
-
 stream-each@^1.1.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/stream-each/-/stream-each-1.2.2.tgz#8e8c463f91da8991778765873fe4d960d8f616bd"
@@ -7000,12 +6972,6 @@ stream-http@^2.3.1:
     readable-stream "^2.2.6"
     to-arraybuffer "^1.0.0"
     xtend "^4.0.0"
-
-stream-json@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/stream-json/-/stream-json-1.1.0.tgz#0a91e84e3cfb017f2446d9023025694982c99e89"
-  dependencies:
-    stream-chain "^2.0.3"
 
 stream-shift@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Important Linux-specific fixes:

 - AppImage should set the correct task bar icon - (as of `v20.26.0`)
 - Include main category for inferred DEB desktop entries (as of `v20.24.5`)