### PR TITLE
1.4.0 Linux RC2

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "1.4.0",
+  "version": "1.4.0-linux2",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/script/electron-builder-linux.yml
+++ b/script/electron-builder-linux.yml
@@ -19,7 +19,7 @@ deb:
     - libxtst6
     - libnss3
     # dugite-native dependencies
-    - libcurl3
+    - libcurl3 | libcurl4
     # keytar dependencies
     - libsecret-1-0
 rpm:


### PR DESCRIPTION
Fixes #60 by supporting Ubuntu distros that prefer `libcurl4` which conflicts with the previous `libcurl3`.