### PR TITLE
Post install & remove for debian package

### DIFF
--- a/script/electron-builder-linux.yml
+++ b/script/electron-builder-linux.yml
@@ -11,6 +11,8 @@ linux:
     - AppImage
   maintainer: 'GitHub, Inc <opensource+desktop@github.com>'
 deb:
+  afterInstall: './script/linux-after-install.sh'
+  afterRemove: './script/linux-after-remove.sh'
   depends:
     # default Electron dependencies
     - gconf2

--- a/script/linux-after-install.sh
+++ b/script/linux-after-install.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+PROFILE_D_FILE="/etc/profile.d/${productFilename}.sh"
+INSTALL_DIR="/opt/${productFilename}"
+SCRIPT="#!/bin/sh
+export PATH=$INSTALL_DIR:\$PATH"
+
+case "$1" in
+    configure)
+      echo "$SCRIPT" > ${PROFILE_D_FILE};
+      . ${PROFILE_D_FILE};
+    ;;
+
+    abort-upgrade|abort-remove|abort-deconfigure)
+    ;;
+
+    *)
+      echo "postinst called with unknown argument \`$1'" >&2
+      exit 1
+    ;;
+esac
+
+exit 0

--- a/script/linux-after-remove.sh
+++ b/script/linux-after-remove.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+PROFILE_D_FILE="/etc/profile.d/${productFilename}.sh"
+
+case "$1" in
+    purge|remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
+      echo "#!/bin/sh" > ${PROFILE_D_FILE};
+      . ${PROFILE_D_FILE};
+      rm ${PROFILE_D_FILE};
+    ;;
+
+    *)
+      echo "postrm called with unknown argument \`$1'" >&2
+      exit 1
+    ;;
+esac
+
+exit 0


### PR DESCRIPTION
Post install script that will add the following bash script to `/etc/profile.d/GitHubDesktop.sh`:
```bash
#!/bin/bash
export PATH=/opt/GitHubDesktop:PATH
```
Clean up in post remove hook.