### PR TITLE
Snap password-manager-service interface

### DIFF
--- a/script/electron-builder-linux.yml
+++ b/script/electron-builder-linux.yml
@@ -40,3 +40,5 @@ snap:
     - libcurl3
     - libsecret-1-0
     - openssh-client
+  plugs:
+    - password-manager-service


### PR DESCRIPTION
Enables support for GNOME Keyring and possibly other 'password managers'.

Fixes: https://github.com/shiftkey/desktop/issues/59