### PR TITLE
package when building on default branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,31 +7,61 @@ trigger:
       - __release-*
       - release-*
 
+resources:
+  repositories:
+    - repository: self
+      checkoutOptions:
+        submodules: true
+
 jobs:
   - job: Linux
     pool:
       vmImage: ubuntu-16.04
     steps:
       - script: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libsecret-1-dev xvfb fakeroot dpkg rpm xz-utils xorriso zsync libxss1 libgconf2-4 libgtk-3-0
-      - task: NodeTool@0
-        inputs:
-          versionSpec: '8.11.1'
-      - task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@2
-        inputs:
-          versionSpec: '1.5.1'
-      - script: |
-          yarn install --force
-        name: Install
-      - script: |
-          yarn build:prod
-        name: Build
+          mkdir -p /tmp/local/.cache
+          mkdir -p /tmp/local/.yarn
+          mkdir -p /tmp/local/.node-gyp
+          mkdir -p /tmp/local/.local
+        displayName: 'Setup local caches'
+      - script:
+          docker run -u $(id -u):$(id -g) -v $(Build.SourcesDirectory):/src -v
+          /tmp/local/.cache:/.cache -v /tmp/local/.yarn:/.yarn -v
+          /tmp/local/.node-gyp:/.node-gyp -v /tmp/local/.local:/.local -w /src
+          shiftkey/github-desktop:trusty-node-yarn-git sh -c "yarn install
+          --force && yarn build:prod"
+        displayName: 'Build in container'
       - script: |
           export DISPLAY=':99.0'
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
           yarn test:setup && yarn test
         name: Test
+      - script:
+          docker run -v $(Build.SourcesDirectory):/src -v
+          /tmp/local/.cache:/.cache -v /tmp/local/.yarn:/.yarn -v
+          /tmp/local/.node-gyp:/.node-gyp -v /tmp/local/.local:/.local -w /src
+          shiftkey/github-desktop:snapcraft-node-yarn sh -c "yarn run package"
+        displayName: 'Package in Container'
+        condition:
+          and(succeeded(), eq(variables['Build.SourceBranch'],
+          'refs/heads/linux'))
+      - task: CopyFiles@2
+        inputs:
+          contents: |
+            dist/*.yml
+            dist/*.AppImage
+            dist/*.deb
+            dist/*.rpm
+            dist/*.snap
+          targetFolder: $(Build.ArtifactStagingDirectory)
+          flattenFolders: true
+        condition:
+          and(succeeded(), eq(variables['Build.SourceBranch'],
+          'refs/heads/linux'))
+      - task: PublishBuildArtifacts@1
+        condition:
+          and(succeeded(), eq(variables['Build.SourceBranch'],
+          'refs/heads/linux'))
 
   - job: Lint
     pool:

--- a/script/docker/snapcraft.Dockerfile
+++ b/script/docker/snapcraft.Dockerfile
@@ -1,0 +1,20 @@
+FROM snapcore/snapcraft
+
+RUN apt -qq install --yes curl gnupg
+
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+
+# add custom tools required for electron-packager
+RUN apt -qq update
+RUN apt -qq install --yes \
+  apt-transport-https \
+  nodejs \
+  yarn \
+  fakeroot \
+  dpkg \
+  rpm \
+  xz-utils \
+  xorriso \
+  zsync

--- a/script/docker/trusty.Dockerfile
+++ b/script/docker/trusty.Dockerfile
@@ -1,0 +1,46 @@
+FROM ubuntu:trusty
+
+RUN apt-get update
+RUN apt-get install --quiet --yes \
+    build-essential \
+    curl \
+    pkg-config \
+    clang \
+    python \
+    # to be able to use add-apt-repository below
+    software-properties-common \
+    python-software-properties \
+    # required to compile keytar
+    libsecret-1-dev \
+    # essential for testing Electron in a headless fashion
+    # https://github.com/electron/electron/blob/master/docs/tutorial/testing-on-headless-ci.md
+    libgtk-3-0 \
+    libxtst6 \
+    libxss1 \
+    libgconf-2-4 \
+    libasound2 \
+    xvfb \
+    # packages required for electron-installer-debian
+    fakeroot \
+    dpkg \
+    # packages required for electron-installer-redhat
+    rpm \
+    # packages required for electron-installer-appimage
+    xz-utils \
+    xorriso \
+    zsync
+
+# ensure we are running a recent version of Git
+RUN add-apt-repository ppa:git-core/ppa
+
+# install the latest LTS version of Node
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+
+# install the latest version of Yarn
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN apt-get update && apt-get install --no-install-recommends --yes --quiet git nodejs yarn
+
+ENV CC clang
+ENV CXX clang++
+ENV npm_config_clang 1


### PR DESCRIPTION
This is the first step in emulating my current Travis setup when the build is good.

Detecting the push was with a tag on Azure Pipelines doesn't seem possible currently (maybe I've missed something) so for the moment I'm going to go with this flow:

 - whenever we're building on `linux` (our default branch), generate the package
 - copy the generated installers and upload them as build artefacts

From there I can design the release pipeline to run whenever I have a candidate build ready - I just need to be mindful of bumping versions because the version number is baked during the build.

TODO:
 
 - [x] see the build fail
 - [x] containerize install & build step to avoid manual setup of dependencies (and control environment)
 - [x] address yarn warnings about not being able to read certain folders
 - [x] containerize package step to run inside snapcraft container
 - [x] upload bits as part of build artefacts
 - [x] add in conditionals so that PRs don't package by default