### PR TITLE
bump dugite to get packaging improvements for Linux

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -26,7 +26,7 @@
     "deep-equal": "^1.0.1",
     "dexie": "^2.0.0",
     "double-ended-queue": "^2.1.0-0",
-    "dugite": "^1.78.0",
+    "dugite": "^1.79.0",
     "electron-window-state": "^4.0.2",
     "event-kit": "^2.0.0",
     "file-uri-to-path": "0.0.2",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -299,10 +299,10 @@ double-ended-queue@^2.1.0-0:
   resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
   integrity sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=
 
-dugite@^1.78.0:
-  version "1.78.0"
-  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.78.0.tgz#830a6dd160997aa3b4f255a5132262ec7aa7d25d"
-  integrity sha512-t3/aKKLWS/8gmh6r7Ev2Mm+QiM/lFioQHyokz4/ORQJsJgZlKS/vxt+fzUTydzMI/1wSYRAGzVkJJMTcnh1NQQ==
+dugite@^1.79.0:
+  version "1.79.0"
+  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.79.0.tgz#4408a1e495c59634f3224f2e0de232290f944f4d"
+  integrity sha512-1iohG+Yj+7wwVNUv+HCWaK5ZeAbqNyxHZf96B65KojBVcvMT29i8Tnh/Ta/KHI7LcI0dQqSqsKJdZozpWjXWKw==
   dependencies:
     checksum "^0.1.1"
     mkdirp "^0.5.1"


### PR DESCRIPTION
## Overview

Fixes https://github.com/desktop/dugite-native/issues/109 

I've had reports from the Atom team - who also consume `dugite` - that this has resolved the reports they've seen about the issue, so the next step is to do the same for Desktop.

## Release notes

Notes: Upgrade embedded Git to address packaging issues for newer Linux distributions
