### PR TITLE
update package names to address clashes on Linux distros

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "desktop",
+  "name": "github-desktop",
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",

--- a/script/dist-info.ts
+++ b/script/dist-info.ts
@@ -26,7 +26,7 @@ export function getExecutableName() {
   if (process.platform === 'win32') {
     return `${getWindowsIdentifierName()}${suffix}`
   } else if (process.platform === 'linux') {
-    return 'desktop'
+    return `github-desktop${suffix}`
   } else {
     return productName
   }

--- a/script/electron-builder-linux.yml
+++ b/script/electron-builder-linux.yml
@@ -1,5 +1,4 @@
-productName: 'GitHubDesktop'
-artifactName: '${productName}-${os}-${arch}-${version}.${ext}'
+artifactName: 'GitHubDesktop-${os}-${version}.${ext}'
 linux:
   category: 'GNOME;GTK;Development'
   packageCategory: 'GNOME;GTK;Development'

--- a/script/linux-after-install.sh
+++ b/script/linux-after-install.sh
@@ -5,12 +5,12 @@ set -e
 PROFILE_D_FILE="/etc/profile.d/${productFilename}.sh"
 INSTALL_DIR="/opt/${productFilename}"
 SCRIPT="#!/bin/sh
-export PATH=$INSTALL_DIR:\$PATH"
+export PATH='$INSTALL_DIR:\$PATH'"
 
 case "$1" in
     configure)
-      echo "$SCRIPT" > ${PROFILE_D_FILE};
-      . ${PROFILE_D_FILE};
+      echo "$SCRIPT" > "${PROFILE_D_FILE}";
+      . "${PROFILE_D_FILE}";
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/script/linux-after-remove.sh
+++ b/script/linux-after-remove.sh
@@ -5,9 +5,9 @@ PROFILE_D_FILE="/etc/profile.d/${productFilename}.sh"
 
 case "$1" in
     purge|remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
-      echo "#!/bin/sh" > ${PROFILE_D_FILE};
-      . ${PROFILE_D_FILE};
-      rm ${PROFILE_D_FILE};
+      echo "#!/bin/sh" > "${PROFILE_D_FILE}";
+      . "${PROFILE_D_FILE}";
+      rm "${PROFILE_D_FILE}";
     ;;
 
     *)


### PR DESCRIPTION
## Overview

I believe addresses some outstanding issues with the `desktop` package name in `app/package.json`, but is likely a breaking change itself - and I'm not sure how important this is for the macOS and Windows builds, so this is a work-in-progress.

Fixes #22 
Fixes #42
Fixes #54

## Description

- [x] test for `/usr/share/applications/desktop.desktop` being renamed to `github-desktop.desktop` (RPM)
 - [x] test `.deb` installer is now named `github-desktop` when installing
 - [x] confirm quoting fixes related to #69 work fine now that `GitHub Desktop` is the `productName` again

## Release notes

Notes: Updated built packages to use `github-desktop` rather than plain `desktop` app name on Linux
