### PR TITLE
fix install scripts to handle spaces in install directory

### DIFF
--- a/script/linux-after-install.sh
+++ b/script/linux-after-install.sh
@@ -4,8 +4,8 @@ set -e
 
 PROFILE_D_FILE="/etc/profile.d/github-desktop.sh"
 INSTALL_DIR="/opt/${productFilename}"
-SCRIPT="#!/bin/sh
-export PATH='$INSTALL_DIR:\$PATH'"
+SCRIPT=$"#!/bin/sh
+export PATH=\"$INSTALL_DIR:\$PATH\""
 
 case "$1" in
     configure)

--- a/script/linux-after-install.sh
+++ b/script/linux-after-install.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-PROFILE_D_FILE="/etc/profile.d/${productFilename}.sh"
+PROFILE_D_FILE="/etc/profile.d/github-desktop.sh"
 INSTALL_DIR="/opt/${productFilename}"
 SCRIPT="#!/bin/sh
 export PATH='$INSTALL_DIR:\$PATH'"

--- a/script/linux-after-remove.sh
+++ b/script/linux-after-remove.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-PROFILE_D_FILE="/etc/profile.d/${productFilename}.sh"
+PROFILE_D_FILE="/etc/profile.d/github-desktop.sh"
 
 case "$1" in
     purge|remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)


### PR DESCRIPTION
## Overview

This was a regression noticed after the package rename in #80, because it introduced spaces into the paths.

**Closes #85**

## Description

- use `github-desktop.sh` for the `profile.d` scripts (they're not controlled by `electron-builder` so we can name these whatever we want)
- tighten up the script emit step to use a `$` prefix (this ensures newlines in strings are preserved) and double-quotes to correctly wrap the new path value

To verify these changes, I extracted the setup into a standalone harness and verified that I could source the generated script and see that `github-desktop` (the main executable) is detected on `PATH`:

```
$ echo $PATH
/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin

$ cat test-script.sh 
#!/bin/bash

set -e

INSTALL_DIR="/opt/GitHub Desktop"
SCRIPT=$"#!/bin/sh
export PATH=\"$INSTALL_DIR:\$PATH\""
PROFILE_D_FILE="/home/parallels/profile.d/github-desktop.sh"

echo "$SCRIPT" > "${PROFILE_D_FILE}";

$ ./test-script.sh 

$ cat ./profile.d/github-desktop.sh 
#!/bin/sh
export PATH="/opt/GitHub Desktop:$PATH"

$ . ./profile.d/github-desktop.sh

$ echo $PATH
/opt/GitHub Desktop:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin

$ which github-desktop
/opt/GitHub Desktop/github-desktop
```

## Release notes

Notes: fix issue with post-install scripts handling spaces in `productName` field
