### PR TITLE
deprecate Travis packaging steps for Azure Pipelines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,6 @@ notifications:
 
 dist: trusty
 
-sudo: false
-
-services:
-  - docker
-
 os: linux
 compiler: clang
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,23 +54,3 @@ script:
 
 after_failure:
   - yarn test:review
-
-after_success:
-  - docker run -v $(pwd):$(pwd) -t snapcore/snapcraft sh -c "cd $(pwd) &&
-    ./script/docker-package.sh"
-
-deploy:
-  provider: releases
-  api_key: $GITHUB_TOKEN
-  file_glob: true
-  file:
-    - ${TRAVIS_BUILD_DIR}/dist/*.yml
-    - ${TRAVIS_BUILD_DIR}/dist/*.AppImage
-    - ${TRAVIS_BUILD_DIR}/dist/*.deb
-    - ${TRAVIS_BUILD_DIR}/dist/*.rpm
-    - ${TRAVIS_BUILD_DIR}/dist/*.snap
-  skip_cleanup: true
-  draft: true
-  tag_name: $TRAVIS_TAG
-  on:
-    tags: true

--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "1.5.0-linux3",
+  "version": "1.5.0-linux4",
   "main": "./main.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Overview

I have a custom Azure Pipelines release process setup that now handles publishing a draft release to GitHub as well as publishing to the edge channel of the Snap store. This PR now switches us over to using those bits, rather than the Travis containerized packaging steps and `deploy` config which has served us well for a long time.

## Description

N/A

## Release notes

Notes: no-notes
