### PR TITLE
make README a bit more focused on Linux usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [GitHub Desktop](https://desktop.github.com)
+# [GitHub Desktop](https://desktop.github.com) - The Linux Fork
 
 [![Travis](https://img.shields.io/travis/desktop/desktop.svg?style=flat-square&label=Travis+CI)](https://travis-ci.org/desktop/desktop)
 [![CircleCI](https://img.shields.io/circleci/project/github/desktop/desktop.svg?style=flat-square&label=CircleCI)](https://circleci.com/gh/desktop/desktop)
@@ -13,72 +13,41 @@ uses [React](https://facebook.github.io/react/).
 
 ![GitHub Desktop screenshot - Windows](https://cloud.githubusercontent.com/assets/359239/26094502/a1f56d02-3a5d-11e7-8799-23c7ba5e5106.png)
 
-## Where can I get it?
+## What is this repository for?
 
-Download the official installer for your operating system:
+This repository contains specific patches on top of the upstream
+`desktop/desktop` repository to support Linux usage.
 
- - [macOS](https://central.github.com/deployments/desktop/desktop/latest/darwin)
- - [Windows](https://central.github.com/deployments/desktop/desktop/latest/win32)
- - [Windows machine-wide install](https://central.github.com/deployments/desktop/desktop/latest/win32?format=msi)
+It also hosts preview packages for various Linux distributions:
 
-There are several community-supported package managers that can be used to install Github Desktop.
- - Windows users can install using [Chocolatey](https://chocolatey.org/) package manager:
-      `c:\> choco install github-desktop`
- - macOS users can install using [Homebrew](https://brew.sh/) package manager:
-      `$ brew cask install github`
- - Arch Linux users can install the latest version from the [AUR](https://aur.archlinux.org/packages/github-desktop/).
+ - AppImage (`.AppImage`)
+ - Debian (`.deb`)
+ - RPM (`.rpm`)
+ - Snap (`.snap`) - also available from [snapcraft.io](https://snapcraft.io/github-desktop)
 
-You can install this alongside your existing GitHub Desktop for Mac or GitHub
-Desktop for Windows application.
+Check out the [latest releases](https://github.com/shiftkey/desktop/releases) to
+help out with testing on your distribution.
 
-**NOTE**: there is no current migration path to import your existing
-repositories into the new application - you can drag-and-drop your repositories
-from disk onto the application to get started.
+If you install the Snap package, ensure you also connect it to your password
+manager:
 
-### Beta Channel
+```shellsession
+$ sudo snap connect github-desktop:password-manager-service
+```
 
-Want to test out new features and get fixes before everyone else? Install the
-beta channel to get access to early builds of Desktop:
+Without this, GitHub Desktop cannot store or retrieve account details it
+requires in the user's keychain.
 
- - [macOS](https://central.github.com/deployments/desktop/desktop/latest/darwin?env=beta)
- - [Windows](https://central.github.com/deployments/desktop/desktop/latest/win32?env=beta)
- 
-## Is GitHub Desktop right for me? What are the primary areas of focus?
+## Other Distributions
 
-[This document](https://github.com/desktop/desktop/blob/master/docs/process/what-is-desktop.md) describes the focus of GitHub Desktop and who the product is most useful for.
+Arch Linux users can install GitHub Desktop from the
+[AUR](https://aur.archlinux.org/packages/github-desktop/).
 
-And to see what the team is working on currently and in the near future, check out the [GitHub Desktop roadmap](https://github.com/desktop/desktop/blob/master/docs/process/roadmap.md).
+## More information
 
-## I have a problem with GitHub Desktop
-
-Note: The [GitHub Desktop Code of Conduct](https://github.com/desktop/desktop/blob/master/CODE_OF_CONDUCT.md) applies in all interactions relating to the GitHub Desktop project.
-
-First, please search the [open issues](https://github.com/desktop/desktop/issues?q=is%3Aopen)
-and [closed issues](https://github.com/desktop/desktop/issues?q=is%3Aclosed)
-to see if your issue hasn't already been reported (it may also be fixed).
-
-There is also a list of [known issues](https://github.com/desktop/desktop/blob/master/docs/known-issues.md)
-that are being tracked against Desktop, and some of these issues have workarounds.
-
-If you can't find an issue that matches what you're seeing, open a [new issue](https://github.com/desktop/desktop/issues/new/choose),
-choose the right template and provide us with enough information to investigate
-further.
-
-## The issue I reported isn't fixed yet. What can I do?
-
-If nobody has responded to your issue in a few days, you're welcome to respond to it with a friendly ping in the issue. Please do not respond more than a second time if nobody has responded. The GitHub Desktop maintainers are constrained in time and resources, and diagnosing individual configurations can be difficult and time consuming. While we'll try to at least get you pointed in the right direction, we can't guarantee we'll be able to dig too deeply into any one person's issue.
-
-## How can I contribute to GitHub Desktop?
-
-The [CONTRIBUTING.md](./.github/CONTRIBUTING.md) document will help you get setup and
-familiar with the source. The [documentation](docs/) folder also contains more
-resources relevant to the project.
-
-If you're looking for something to work on, check out the [help wanted](https://github.com/desktop/desktop/issues?q=is%3Aissue+is%3Aopen+label%3A%22help%20wanted%22) label.
-
-## More Resources
-
-See [desktop.github.com](https://desktop.github.com) for more product-oriented
+Please check out the [README](https://github.com/desktop/desktop#github-desktop)
+on the upstream [GitHub Desktop project](https://github.com/desktop/desktop) and
+[desktop.github.com](https://desktop.github.com) for more product-oriented
 information about GitHub Desktop.
 
 ## License

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -13,6 +13,26 @@ On Windows you have two options:
  - Download the `GitHubDesktopSetup.exe` and run it to install it for the current user.
  - Download the `GitHubDesktopSetup.msi` and run it to install a machine-wide version of GitHub Desktop - each logged-in user will then be able to run GitHub Desktop from the program at `%PROGRAMFILES(x86)\GitHub Desktop Installer\desktop.exe`
 
+### Linux
+
+On Linux there are four different package formats available, depending on your
+distribution:
+
+ - AppImage (`.AppImage`)
+ - Debian (`.deb`)
+ - RPM (`.rpm`)
+ - Snap (`.snap`) - also available from [snapcraft.io](https://snapcraft.io/github-desktop)
+
+If you install the Snap package, ensure you also connect it to your password
+manager:
+
+```shellsession
+$ sudo snap connect github-desktop:password-manager-service
+```
+
+Without this, GitHub Desktop cannot store or retrieve account details it
+requires in the user's keychain.
+
 ## Data Directories
 
 GitHub Desktop will create directories to manage the files and data it needs to function. If you manage a network of computers and want to install GitHub Desktop, here is more information about how things work.
@@ -24,6 +44,13 @@ GitHub Desktop will create directories to manage the files and data it needs to 
 
  - `%LOCALAPPDATA%\GitHubDesktop\` - contains the latest versions of the app, and some older versions if the user has updated from a previous version.
  - `%APPDATA%\GitHub Desktop\` - this directory contains user-specific data which the application requires to run, and is created on launch if it doesn't exist. Log files are also stored in this location.
+
+### Linux
+
+This varies based on the installer chosen:
+
+ - AppImage, Debian and RPM: `~/.config/GitHub Desktop/`
+ - Snap: `~/snap/github-desktop/current/.config/GitHub Desktop/`
 
 ## Log Files
 


### PR DESCRIPTION
## Overview

Tidying up some docs to make them more Linux-focused.

**Closes #83**
**Closes #73**

## Description

Rendered markdown:

  - [README.md](https://github.com/shiftkey/desktop/blob/add-some-docs/README.md)
  - [`docs/installation.md`](https://github.com/shiftkey/desktop/blob/add-some-docs/docs/installation.md)

## Release notes

Notes: no-notes
