### PR TITLE
use environment variables to control which jobs are run as part of a build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,9 @@
 variables:
   PYTHON: 'python2.7'
+  # flags to enable/disable agents without needing to remove config
+  BUILD_WINDOWS: 'false'
+  BUILD_MACOS: 'false'
+  BUILD_LINUX: 'true'
 
 resources:
   repositories:
@@ -9,6 +13,7 @@ resources:
 
 jobs:
   - job: Windows
+    condition: eq(variables['BUILD_WINDOWS'], 'true')
     pool:
       vmImage: vs2017-win2016
     steps:
@@ -29,6 +34,7 @@ jobs:
         name: Test
 
   - job: Linux
+    condition: eq(variables['BUILD_LINUX'], 'true')
     pool:
       vmImage: ubuntu-16.04
     steps:
@@ -78,6 +84,7 @@ jobs:
           'refs/tags/'))
 
   - job: macOS
+    condition: eq(variables['BUILD_MACOS'], 'true')
     pool:
       vmImage: xcode9-macos10.13
     steps:


### PR DESCRIPTION
## Overview

I'm only interested in running the Linux agents on this fork, but I don't want to have to remove the configs for the other platforms, so this PR allows me to programatically control which jobs are run on this fork.

## Description

With this change, I see the Windows and macOS agents are skipped:

<img width="351" src="https://user-images.githubusercontent.com/359239/48868460-080e9300-edb0-11e8-85a9-cd9fccf0234f.png">

## Release notes


Notes: no-notes
