### PR TITLE
Fixed SSH key permission in snap

### DIFF
--- a/script/electron-builder-linux.yml
+++ b/script/electron-builder-linux.yml
@@ -50,5 +50,6 @@ snap:
     - network
     - opengl
     - password-manager-service
+    - ssh-keys
     - unity7
     - wayland


### PR DESCRIPTION
## Overview

<!--
What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one to allow for discussion before opening this PR.
(You can open a new issue at https://github.com/desktop/desktop/issues/new/choose)
-->
**Closes #96**

## Description

- Added `ssh-key` to the list of plugs

TODO:
- As with #59, documentation on connecting the plug for the first time should be included somewhere in documentation. The command used to connect the plug: `sudo snap connect github-desktop:ssh-keys`

## Release notes

<!--
If this is related to a feature, bugfix or improvement, please add a summary of the change to assist with drafting the release notes when this pull request is merged.

Some examples:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs 
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

If you don't believe this change needs to be mentioned in the release notes, write "no-notes" to indicate this can be skipped.
-->

Notes:
- Fixes authentication problem with SSH remote in snap installations.