### PR TITLE
Switch snap package back to classic confinement

### DIFF
--- a/script/electron-builder-linux.yml
+++ b/script/electron-builder-linux.yml
@@ -35,20 +35,11 @@ rpm:
     # keytar dependencies
     - libsecret
 snap:
-  confinement: 'strict'
+  confinement: 'classic'
   stagePackages:
     - default
     - libcurl3
     - libsecret-1-0
     - openssh-client
   plugs:
-    - browser-support
-    - desktop
-    - desktop-legacy
-    - gsettings
-    - home
-    - network
-    - opengl
     - password-manager-service
-    - unity7
-    - wayland


### PR DESCRIPTION
Revert "trying this set of plugs so Desktop works in a strict confinement"

This reverts commit a6c4959012a3b824405dac36650e520bc4e77b22.

## Overview

<!--
What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one to allow for discussion before opening this PR.
(You can open a new issue at https://github.com/desktop/desktop/issues/new/choose)
-->
Closes #91 #95 #96 #98 
Closes #104 

Undoes #90 

## Description
Switch snap package back to classic confinement, as strict confinement is causing multiple issues. And after inspecting some of the similar applications, they are all using classic confinement.

## Release notes

<!--
If this is related to a feature, bugfix or improvement, please add a summary of the change to assist with drafting the release notes when this pull request is merged.

Some examples:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs 
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

If you don't believe this change needs to be mentioned in the release notes, write "no-notes" to indicate this can be skipped.
-->

Notes: