### PR TITLE
add gettext dependency to stagePackages so it is available at runtime

### DIFF
--- a/script/electron-builder-linux.yml
+++ b/script/electron-builder-linux.yml
@@ -41,6 +41,7 @@ snap:
     - libcurl3
     - libsecret-1-0
     - openssh-client
+    - gettext
   plugs:
     - browser-support
     - desktop


### PR DESCRIPTION
## Overview

**Closes #91**

This adds the `gettext` dependency when generating the Snap installer. The missing `/usr/bin/gettext.sh` is actually part of the `gettext-base` package but we can verify this works first before trying to slim down the installer size.

## Release notes

Notes: Add missing dependency to Snap package to address issues with some Git operations
