### PR TITLE
strip out unnecessary packages now that electron-builder is in charge

### DIFF
--- a/script/docker/snapcraft.Dockerfile
+++ b/script/docker/snapcraft.Dockerfile
@@ -6,15 +6,12 @@ RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 
-# add custom tools required for electron-packager
+# add custom tools required for electron-builder
 RUN apt -qq update
 RUN apt -qq install --yes \
-  apt-transport-https \
   nodejs \
   yarn \
-  fakeroot \
-  dpkg \
-  rpm \
-  xz-utils \
-  xorriso \
-  zsync
+  # needed for pacman builds
+  bsdtar \
+  # needed for RPM builds
+  rpm

--- a/script/docker/trusty.Dockerfile
+++ b/script/docker/trusty.Dockerfile
@@ -19,16 +19,7 @@ RUN apt-get install --quiet --yes \
     libxss1 \
     libgconf-2-4 \
     libasound2 \
-    xvfb \
-    # packages required for electron-installer-debian
-    fakeroot \
-    dpkg \
-    # packages required for electron-installer-redhat
-    rpm \
-    # packages required for electron-installer-appimage
-    xz-utils \
-    xorriso \
-    zsync
+    xvfb
 
 # ensure we are running a recent version of Git
 RUN add-apt-repository ppa:git-core/ppa


### PR DESCRIPTION
## Overview

Stripping out some old dependencies now that our `electron-builder` usage is relatively stable

## Release notes

Notes: no-notes
