### PR TITLE
[HOLD] use edge tooling for building snaps

### DIFF
--- a/script/docker/snapcraft.Dockerfile
+++ b/script/docker/snapcraft.Dockerfile
@@ -7,11 +7,19 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 
 # add custom tools required for electron-builder
-RUN apt-get -qq update
-RUN apt-get -qq install --yes \
-  nodejs \
-  yarn \
-  # needed for pacman builds
-  bsdtar \
-  # needed for RPM builds
-  rpm
+RUN apt-get -qq \
+    # yarn's public key is currently expired, so we have to hack around it
+    -o Acquire::AllowInsecureRepositories=true \
+    -o Acquire::AllowDowngradeToInsecureRepositories=true \
+    update
+RUN apt-get -qq \
+    # yarn's public key is currently expired, so we have to hack around it
+    --allow-unauthenticated \
+    --yes \
+    install  \
+    nodejs \
+    yarn \
+    # needed for pacman builds
+    bsdtar \
+    # needed for RPM builds
+    rpm

--- a/script/docker/snapcraft.Dockerfile
+++ b/script/docker/snapcraft.Dockerfile
@@ -7,8 +7,8 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 
 # add custom tools required for electron-builder
-RUN apt -qq update
-RUN apt -qq install --yes \
+RUN apt-get -qq update
+RUN apt-get -qq install --yes \
   nodejs \
   yarn \
   # needed for pacman builds

--- a/script/docker/snapcraft.Dockerfile
+++ b/script/docker/snapcraft.Dockerfile
@@ -1,4 +1,4 @@
-FROM snapcore/snapcraft
+FROM snapcore/snapcraft:edge
 
 RUN apt -qq install --yes curl gnupg
 


### PR DESCRIPTION
## Overview

This **does not** unblock the issues plaguing the `electron-builder` migration in #111 by using the latest tooling provided in the Docker container. I need to merge it in first because I have auto-publishing to Docker Hub enabled for this repository.

## Release notes

Notes: no-notes
