### PR TITLE
revert to using classic confinement for snap

### DIFF
--- a/script/electron-builder-linux.yml
+++ b/script/electron-builder-linux.yml
@@ -38,48 +38,11 @@ rpm:
     # keytar dependencies
     - libsecret
 snap:
-  confinement: 'strict'
+  confinement: 'classic'
   stagePackages:
     - default
     - libcurl3
     - openssh-client
     - gettext
-  plugs:
-    - browser-support
-    - desktop
-    - desktop-legacy
-    - gsettings
-    - home
-    - network
-    - opengl
-    - password-manager-service
-    - ssh-keys
-    - unity7
-    - wayland
-    # additional plugs to pick up the GTK theme and icons from the system, mouse cursor theme still not fixed
-    - {
-        'gtk-3-themes':
-          {
-            'interface': 'content',
-            'target': '$SNAP/data-dir/themes',
-            'default-provider': 'gtk-common-themes:gtk-3-themes',
-          },
-      }
-    - {
-        'icon-themes':
-          {
-            'interface': 'content',
-            'target': '$SNAP/data-dir/icons',
-            'default-provider': 'gtk-common-themes:icon-themes',
-          },
-      }
-    - {
-        'sound-themes':
-          {
-            'interface': 'content',
-            'target': '$SNAP/data-dir/sounds',
-            'default-provider': 'gtk-common-themes:sounds-themes',
-          },
-      }
   environment:
     DISABLE_WAYLAND: 1


### PR DESCRIPTION
## Overview

Part of the work required to address #116 

## Description

This PR cleans up the attempts to get GitHub Desktop working within the strict confinement. Once we have approval to publish with the `classic` confinement, we'll hopefully get this onto the `beta` channel to verify the changes.

## Release notes

Notes: no-notes
