### PR TITLE
in-app migration guide for Snap installs

### DIFF
--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -45,6 +45,7 @@ export enum PopupType {
   PushNeedsPull,
   LocalChangesOverwritten,
   RebaseConflicts,
+  SnapMigrationGuide,
 }
 
 export type Popup =
@@ -172,4 +173,7 @@ export type Popup =
       repository: Repository
       baseBranch?: string
       targetBranch: string
+    }
+  | {
+      type: PopupType.SnapMigrationGuide
     }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -95,6 +95,7 @@ import { UsageStatsChange } from './usage-stats-change'
 import { PushNeedsPullWarning } from './push-needs-pull'
 import { LocalChangesOverwrittenWarning } from './local-changes-overwritten'
 import { RebaseConflictsDialog } from './rebase'
+import { detectSnapInstall, SnapMigrationGuide } from './snap-migration-guide'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -275,6 +276,14 @@ export class App extends React.Component<IAppProps, IAppState> {
 
     log.info(`launching: ${getVersion()} (${getOS()})`)
     log.info(`execPath: '${process.execPath}'`)
+
+    if (__LINUX__) {
+      detectSnapInstall().then(found => {
+        if (found) {
+          this.showPopup({ type: PopupType.SnapMigrationGuide })
+        }
+      })
+    }
   }
 
   private onMenuEvent(name: MenuEvent): any {
@@ -1573,6 +1582,8 @@ export class App extends React.Component<IAppProps, IAppState> {
           />
         )
       }
+      case PopupType.SnapMigrationGuide:
+        return <SnapMigrationGuide onDismissed={this.onPopupDismissed} />
       default:
         return assertNever(popup, `Unknown popup type: ${popup}`)
     }

--- a/app/src/ui/snap-migration-guide/detect-snap-install.ts
+++ b/app/src/ui/snap-migration-guide/detect-snap-install.ts
@@ -1,0 +1,31 @@
+import { spawnSync } from 'child_process'
+
+// example of matching string in stdout:
+// `github-desktop  1.6.0-linux1  40   edge      snapcrafters  private`
+const snapInstallRe = /github-desktop\s*([\.0-9\-]*[0-9a-z]*)\s*\d{1,}\s*(edge)\s*snapcrafters.*/
+
+export async function detectSnapInstall(): Promise<boolean> {
+  return new Promise<boolean>((resolve, reject) => {
+    try {
+      const result = spawnSync('snap', ['list', 'github-desktop'])
+
+      if (result.error != null) {
+        resolve(false)
+        return
+      }
+
+      const lines = result.stdout
+      const match = snapInstallRe.exec(lines)
+      if (match === null) {
+        resolve(false)
+        return
+      }
+
+      const channel = match[2]
+
+      resolve(channel === 'edge')
+    } catch {
+      resolve(false)
+    }
+  })
+}

--- a/app/src/ui/snap-migration-guide/index.ts
+++ b/app/src/ui/snap-migration-guide/index.ts
@@ -1,0 +1,2 @@
+export { detectSnapInstall } from './detect-snap-install'
+export { SnapMigrationGuide } from './snap-migration-guide'

--- a/app/src/ui/snap-migration-guide/snap-migration-guide.tsx
+++ b/app/src/ui/snap-migration-guide/snap-migration-guide.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react'
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { Ref } from '../lib/ref'
+import { ButtonGroup } from '../lib/button-group'
+import { Button } from '../lib/button'
+
+interface ISnapMigrationGuideProps {
+  readonly onDismissed: () => void
+}
+
+export class SnapMigrationGuide extends React.Component<
+  ISnapMigrationGuideProps,
+  {}
+> {
+  public render() {
+    const commands = `$ snap uninstall github-desktop
+$ snap install --beta github-desktop`
+
+    return (
+      <Dialog
+        id="snap-migration"
+        title="Snap Channel Migration Needed"
+        dismissable={false}
+        onDismissed={this.props.onDismissed}
+        type="warning"
+      >
+        <DialogContent>
+          <p>
+            The Snap version of GitHub Desktop needs to be upgraded manually as
+            migrating from using the <Ref>strict</Ref> enclosure to the{' '}
+            <Ref>classic</Ref> enclosure requires your consent. You will need to
+            run these commands to upgrade manually to the beta channel which has
+            the change of confinement.
+          </p>
+          <pre className="commands">{commands}</pre>
+          <p>
+            As this channel will not be getting any further updates while we
+            perform this transition,{' '}
+            <strong>we recomend upgrading as soon as possible</strong> to get
+            the latest Desktop builds.
+          </p>
+        </DialogContent>
+
+        <DialogFooter>
+          <ButtonGroup destructive={true}>
+            <Button onClick={this.props.onDismissed}>Close</Button>
+          </ButtonGroup>
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+}

--- a/app/src/ui/snap-migration-guide/snap-migration-guide.tsx
+++ b/app/src/ui/snap-migration-guide/snap-migration-guide.tsx
@@ -13,8 +13,8 @@ export class SnapMigrationGuide extends React.Component<
   {}
 > {
   public render() {
-    const commands = `$ snap uninstall github-desktop
-$ snap install --beta github-desktop`
+    const commands = `$ snap remove github-desktop
+$ snap install github-desktop --beta --classic`
 
     return (
       <Dialog


### PR DESCRIPTION
## Overview

Part of the work to address #116 

## Description

- [x] wireup flow to show a dialog to the user 
- [x] get builds enabled
- [x] am i correctly closing the dialog?
- [x] write the proper commands to run in the dialog
- [x] detect when a Snap `edge` build for GitHub Desktop is installed
- [x] handle situation where `snap` command errors  -> do nothing
- [x] handle situation where `snap` doesn't return any `stdout` -> do nothing
- [x] handle situation where `snap` returns `beta` -> do nothing

## Screenshots

<img width="613" src="https://user-images.githubusercontent.com/359239/51354510-3c3dc180-1a8a-11e9-9b19-e0daf154ad02.png">

<img width="616" src="https://user-images.githubusercontent.com/359239/51354496-2f20d280-1a8a-11e9-85df-9bf8e370b1d9.png">

## Release notes

Notes:
