### PR TITLE
Snap: use system theme and xwayland

### DIFF
--- a/script/electron-builder-linux.yml
+++ b/script/electron-builder-linux.yml
@@ -56,3 +56,30 @@ snap:
     - ssh-keys
     - unity7
     - wayland
+    # additional plugs to pick up the GTK theme and icons from the system, mouse cursor theme still not fixed
+    - {
+        'gtk-3-themes':
+          {
+            'interface': 'content',
+            'target': '$SNAP/data-dir/themes',
+            'default-provider': 'gtk-common-themes:gtk-3-themes',
+          },
+      }
+    - {
+        'icon-themes':
+          {
+            'interface': 'content',
+            'target': '$SNAP/data-dir/icons',
+            'default-provider': 'gtk-common-themes:icon-themes',
+          },
+      }
+    - {
+        'sound-themes':
+          {
+            'interface': 'content',
+            'target': '$SNAP/data-dir/sounds',
+            'default-provider': 'gtk-common-themes:sounds-themes',
+          },
+      }
+  environment:
+    DISABLE_WAYLAND: 1


### PR DESCRIPTION
Hello,
the snap doesn't launch under Wayland, I propose these changes which at the moment is the standard way to get it running by using XWayland until electron supports Wayland natively. Additionally the added plugs let the snap use the default system gtk and icon theme when available as snap (like Yaru, Ambiance, Adwaita).

I contributed recently the same changes to another electron app which now works fine, except the cursor theme still being ugly (fallback theme), please see the following discussions for more details:
https://github.com/vladimiry/email-securely-app/issues/104#issuecomment-463803534
vladimiry/email-securely-app#109