### PR TITLE
drop custom NPM environment variables

### DIFF
--- a/script/docker/trusty.Dockerfile
+++ b/script/docker/trusty.Dockerfile
@@ -31,7 +31,3 @@ RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update && apt-get install --no-install-recommends --yes --quiet git nodejs yarn
-
-ENV CC clang
-ENV CXX clang++
-ENV npm_config_clang 1


### PR DESCRIPTION
## Overview

The Docker container used to build Linux has had a recent issue with building `fs-admin`:

```
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/4.8/../../../../include/c++/4.8/ext/string_conversions.h:43:
/usr/bin/../lib/gcc/x86_64-linux-gnu/4.8/../../../../include/c++/4.8/cstdio:120:11: error: no member named 'gets' in the global namespace
  using ::gets;
        ~~^
```

I believe it's down to enabling `clang` for the native module toolchain (we don't set this on the main project).

## Release notes

Notes: no-notes
