### PR TITLE
use the app menu bar for Linux instead of the default chrome

### DIFF
--- a/app/src/main-process/app-window.ts
+++ b/app/src/main-process/app-window.ts
@@ -60,6 +60,7 @@ export class AppWindow {
     } else if (__WIN32__) {
       windowOptions.frame = false
     } else if (__LINUX__) {
+      windowOptions.frame = false
       windowOptions.icon = path.join(__dirname, 'static', 'icon-logo.png')
     }
 

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -986,8 +986,8 @@ export class App extends React.Component<IAppProps, IAppState> {
    * on Windows.
    */
   private renderAppMenuBar() {
-    // We only render the app menu bar on Windows
-    if (!__WIN32__) {
+    // We render the app menu bar on Windows and Linux
+    if (__DARWIN__) {
       return null
     }
 
@@ -1046,13 +1046,16 @@ export class App extends React.Component<IAppProps, IAppState> {
     // When we're in full-screen mode on Windows we only need to render
     // the title bar when the menu bar is active. On other platforms we
     // never render the title bar while in full-screen mode.
+
+    const appMenuPlatform = __WIN32__ || __LINUX__
+
     if (inFullScreen) {
-      if (!__WIN32__ || !menuBarActive) {
+      if (!appMenuPlatform || !menuBarActive) {
         return null
       }
     }
 
-    const showAppIcon = __WIN32__ && !this.state.showWelcomeFlow
+    const showAppIcon = appMenuPlatform && !this.state.showWelcomeFlow
 
     return (
       <TitleBar

--- a/app/src/ui/window/title-bar.tsx
+++ b/app/src/ui/window/title-bar.tsx
@@ -84,8 +84,11 @@ export class TitleBar extends React.Component<ITitleBarProps, ITitleBarState> {
     const inFullScreen = this.props.windowState === 'full-screen'
     const isMaximized = this.props.windowState === 'maximized'
 
+    const appMenuPlatform = __WIN32__ || __LINUX__
+
     // No Windows controls when we're in full-screen mode.
-    const winControls = __WIN32__ && !inFullScreen ? <WindowControls /> : null
+    const winControls =
+      appMenuPlatform && !inFullScreen ? <WindowControls /> : null
 
     // On Windows it's not possible to resize a frameless window if the
     // element that sits flush along the window edge has -webkit-app-region: drag.

--- a/app/src/ui/window/window-controls.tsx
+++ b/app/src/ui/window/window-controls.tsx
@@ -97,8 +97,8 @@ export class WindowControls extends React.Component<{}, IWindowControlState> {
   }
 
   public render() {
-    // We only know how to render fake Windows-y controls
-    if (!__WIN32__) {
+    // render the faux window controls for Windows and Linux builds
+    if (!__DARWIN__) {
       return <span />
     }
 

--- a/app/styles/mixins/_platform.scss
+++ b/app/styles/mixins/_platform.scss
@@ -41,3 +41,25 @@
     @content;
   }
 }
+
+// A mixin which takes a content block that should only
+// be applied when the current (real or emulated) operating
+// system is Linux.
+//
+// This helper mixin is useful in so far that it allows us
+// to keep platform specific styles next to cross-platform
+// styles instead of splitting them out and possibly forgetting
+// about them.
+@mixin linux {
+  body.platform-linux & {
+    @content;
+  }
+}
+
+// An exact copy of the linux mixin except that it allows for
+// writing base-level rules
+@mixin linux-context {
+  body.platform-linux {
+    @content;
+  }
+}

--- a/app/styles/ui/window/_title-bar.scss
+++ b/app/styles/ui/window/_title-bar.scss
@@ -27,6 +27,18 @@
     }
   }
 
+  @include linux {
+    height: var(--win32-title-bar-height);
+    background: var(--win32-title-bar-background-color);
+    border-bottom: 1px solid #000;
+
+    .app-icon {
+      color: var(--toolbar-button-secondary-color);
+      margin: 0 var(--spacing);
+      align-self: center;
+    }
+  }
+
   .resize-handle {
     position: absolute;
     top: 0px;


### PR DESCRIPTION
## Overview

**Closes #114**

## Description

Currently when you run the app on Linux it uses the default chrome of the shell to render the menu and the minimize/maximize/close buttons:

<img width="934" src="https://user-images.githubusercontent.com/359239/55687474-b839fe00-5943-11e9-9ece-467a1ba8c858.png">

<img width="923" src="https://user-images.githubusercontent.com/359239/55687540-5ded6d00-5944-11e9-92d4-91a088f674ae.png">

This PR updates the Linux build to use the custom app menu we use on Windows, which should help with making the app feel more polished:

<img width="946" src="https://user-images.githubusercontent.com/359239/55687515-123ac380-5944-11e9-9191-49649aeff65e.png">

<img width="942" src="https://user-images.githubusercontent.com/359239/55687529-42826200-5944-11e9-8d75-d919dd3ef60f.png">

## Release notes

Notes: `[Improved] use styled app menu rather than native chrome on Linux`
