### PR TITLE
revert workaround to ensure we build for all platforms

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,9 +1,5 @@
 variables:
   PYTHON: 'python2.7'
-  # flags to enable/disable agents without needing to remove config
-  BUILD_WINDOWS: 'false'
-  BUILD_MACOS: 'false'
-  BUILD_LINUX: 'true'
 
 resources:
   repositories:
@@ -30,7 +26,6 @@ pr:
 
 jobs:
   - job: Windows
-    condition: eq(variables['BUILD_WINDOWS'], 'true')
     pool:
       vmImage: vs2017-win2016
     steps:
@@ -63,7 +58,6 @@ jobs:
         condition: always()
 
   - job: Linux
-    condition: eq(variables['BUILD_LINUX'], 'true')
     pool:
       vmImage: ubuntu-16.04
     steps:
@@ -122,7 +116,6 @@ jobs:
         condition: always()
 
   - job: macOS
-    condition: eq(variables['BUILD_MACOS'], 'true')
     pool:
       vmImage: xcode9-macos10.13
     steps:


### PR DESCRIPTION
## Overview

I was originally thinking of upstreaming this patch, but instead I think it's just going to be easier to ensure this fork keeps building fine for all platforms.

## Release notes

Notes: update Azure Pipelines configuration to run for all platforms
