### PR TITLE
drop minimum constraint on AppWindow for Linux users

### DIFF
--- a/app/src/main-process/app-window.ts
+++ b/app/src/main-process/app-window.ts
@@ -54,6 +54,12 @@ export class AppWindow {
     } else if (__LINUX__) {
       windowOptions.frame = false
       windowOptions.icon = path.join(__dirname, 'static', 'icon-logo.png')
+
+      // relax restriction here for users trying to run app at a small
+      // resolution and any other side-effects of dropping this restriction are
+      // currently unsupported
+      delete windowOptions.minHeight
+      delete windowOptions.minWidth
     }
 
     this.window = new BrowserWindow(windowOptions)


### PR DESCRIPTION
## Overview

**Closes #65**

## Description

This should be the bare minimum to support users trying to run the app at resolutions like 1024x768

## Release notes

Notes: drop restrictions for minimum height and width for users who are using Desktop on low-resolution displays
