### PR TITLE
update linux.ts to include snap atom

### DIFF
--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -64,9 +64,9 @@ async function getFirstPathIfAvailable(
 async function getEditorPath(editor: ExternalEditor): Promise<string | null> {
   switch (editor) {
     case ExternalEditor.Atom:
-      return getPathIfAvailable('/usr/bin/atom')
+      return getFirstPathIfAvailable(['/snap/bin/atom', '/usr/bin/atom'])
     case ExternalEditor.VSCode:
-      return getPathIfAvailable('/usr/bin/code')
+      return getFirstPathIfAvailable(['/snap/bin/code', '/usr/bin/code'])
     case ExternalEditor.VSCodeInsiders:
       return getFirstPathIfAvailable([
         '/snap/bin/code-insiders',


### PR DESCRIPTION

## Overview

Addresses #147

## Description

- Allows Atom to be detected as an external editor when installed as a snap

## Release notes

- Fixes problem with the Snapcraft version of Atom not being recognized as installed
