### PR TITLE
Add gnome-keyring as deb dependency

### DIFF
--- a/script/electron-builder-linux.yml
+++ b/script/electron-builder-linux.yml
@@ -37,6 +37,7 @@ rpm:
     - libcurl
     # keytar dependencies
     - libsecret
+    - gnome-keyring
 snap:
   confinement: 'classic'
   stagePackages:

--- a/script/electron-builder-linux.yml
+++ b/script/electron-builder-linux.yml
@@ -27,6 +27,7 @@ deb:
     - libcurl3 | libcurl4
     # keytar dependencies
     - libsecret-1-0
+    - gnome-keyring
 rpm:
   depends:
     # default Electron dependencies


### PR DESCRIPTION
Closes https://github.com/shiftkey/desktop/issues/180

## Description

Add gnome-keyring as deb dependency

### Screenshots

N/A

## Release notes

Notes: no-notes