### PR TITLE
bump Windows and macOS virtual machine images

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -119,7 +119,7 @@ jobs:
 
   - job: macOS
     pool:
-      vmImage: xcode10-macOS-10.15
+      vmImage: macOS-10.15
     steps:
       - task: NodeTool@0
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,7 @@ pr:
 jobs:
   - job: Windows
     pool:
-      vmImage: vs2017-win2016
+      vmImage: vs2017-windows-2019
     steps:
       - task: NodeTool@0
         inputs:
@@ -119,7 +119,7 @@ jobs:
 
   - job: macOS
     pool:
-      vmImage: xcode9-macos10.13
+      vmImage: xcode10-macOS-10.15
     steps:
       - task: NodeTool@0
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,7 @@ pr:
 jobs:
   - job: Windows
     pool:
-      vmImage: vs2017-windows-2019
+      vmImage: windows-2019
     steps:
       - task: NodeTool@0
         inputs:


### PR DESCRIPTION
Related to https://devblogs.microsoft.com/devops/removing-older-images-in-azure-pipelines-hosted-pools/

Also bumping the Windows image to Server 2019 - shouldn't cause any problems :crossed_fingers: 