### PR TITLE
Added linux CLI

### DIFF
--- a/app/src/cli/open-desktop.ts
+++ b/app/src/cli/open-desktop.ts
@@ -12,10 +12,12 @@ export function openDesktop(url: string = '') {
     return ChildProcess.spawn('open', [url], { env })
   } else if (__WIN32__) {
     return ChildProcess.spawn('cmd', ['/c', 'start', url], { env })
+  } else if (__LINUX__) {
+    return ChildProcess.spawn('xdg-open', [url], { env })
   } else {
     throw new Error(
       `Desktop command line interface not currently supported on platform ${
-        process.platform
+      process.platform
       }`
     )
   }

--- a/app/static/linux/github.sh
+++ b/app/static/linux/github.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+if [ ! -L $0 ]; then
+	# if path is not a symlink, find relatively
+	GITHUB_PATH="../../.$(dirname $0)"
+else
+	if command -v readlink >/dev/null; then
+		# if readlink exists, follow the symlink and find relatively
+		SYMLINK=$(readlink -f "$0")
+		GITHUB_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$SYMLINK")")")")
+	else
+		# else use the standard install location
+		GITHUB_PATH="/opt/GitHub Desktop"
+	fi
+fi
+BINARY_NAME="github-desktop"
+ELECTRON="$GITHUB_PATH/$BINARY_NAME"
+CLI="$GITHUB_PATH/resources/app/cli.js"
+
+ELECTRON_RUN_AS_NODE=1 "$ELECTRON" "$CLI" "$@"
+
+exit $?


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Partially addresses #32

## Description

Added github.sh script to launch electron app from CLI, and added linux environment to CLI file; tested successfully in Elementary OS 5.1.2

Still TODO: needs modification on linux-after-install script to export PATH

### Screenshots

![image](https://user-images.githubusercontent.com/55799997/76903519-2d0ffa80-686c-11ea-87e1-eed53b790596.png)

## Release notes

Notes: Added compatibility in electron cli.js for linux clients
