### PR TITLE
CLI Compatibility for Linux

### DIFF
--- a/app/src/cli/open-desktop.ts
+++ b/app/src/cli/open-desktop.ts
@@ -12,10 +12,12 @@ export function openDesktop(url: string = '') {
     return ChildProcess.spawn('open', [url], { env })
   } else if (__WIN32__) {
     return ChildProcess.spawn('cmd', ['/c', 'start', url], { env })
+  } else if (__LINUX__) {
+    return ChildProcess.spawn('xdg-open', [url], { env })
   } else {
     throw new Error(
       `Desktop command line interface not currently supported on platform ${
-        process.platform
+      process.platform
       }`
     )
   }

--- a/app/src/cli/open-desktop.ts
+++ b/app/src/cli/open-desktop.ts
@@ -17,7 +17,7 @@ export function openDesktop(url: string = '') {
   } else {
     throw new Error(
       `Desktop command line interface not currently supported on platform ${
-      process.platform
+        process.platform
       }`
     )
   }

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -11,6 +11,7 @@ export enum ExternalEditor {
   SublimeText = 'Sublime Text',
   Typora = 'Typora',
   SlickEdit = 'SlickEdit',
+  ElementaryCode = 'Code',
 }
 
 export function parse(label: string): ExternalEditor | null {
@@ -40,6 +41,10 @@ export function parse(label: string): ExternalEditor | null {
 
   if (label === ExternalEditor.SlickEdit) {
     return ExternalEditor.SlickEdit
+  }
+
+  if (label === ExternalEditor.ElementaryCode) {
+    return ExternalEditor.ElementaryCode
   }
 
   return null
@@ -85,6 +90,9 @@ async function getEditorPath(editor: ExternalEditor): Promise<string | null> {
         '/opt/slickedit-pro2016/bin/vs',
         '/opt/slickedit-pro2015/bin/vs',
       ])
+    case ExternalEditor.ElementaryCode:
+      return getPathIfAvailable('/usr/bin/io.elementary.code')
+
     default:
       return assertNever(editor, `Unknown editor: ${editor}`)
   }
@@ -103,6 +111,7 @@ export async function getAvailableEditors(): Promise<
     sublimePath,
     typoraPath,
     slickeditPath,
+    elementaryCodePath,
   ] = await Promise.all([
     getEditorPath(ExternalEditor.Atom),
     getEditorPath(ExternalEditor.VSCode),
@@ -111,6 +120,7 @@ export async function getAvailableEditors(): Promise<
     getEditorPath(ExternalEditor.SublimeText),
     getEditorPath(ExternalEditor.Typora),
     getEditorPath(ExternalEditor.SlickEdit),
+    getEditorPath(ExternalEditor.ElementaryCode),
   ])
 
   if (atomPath) {
@@ -139,6 +149,13 @@ export async function getAvailableEditors(): Promise<
 
   if (slickeditPath) {
     results.push({ editor: ExternalEditor.SlickEdit, path: slickeditPath })
+  }
+
+  if (elementaryCodePath) {
+    results.push({
+      editor: ExternalEditor.ElementaryCode,
+      path: elementaryCodePath,
+    })
   }
 
   return results

--- a/app/src/lib/editors/shared.ts
+++ b/app/src/lib/editors/shared.ts
@@ -2,7 +2,10 @@ import * as Darwin from './darwin'
 import * as Win32 from './win32'
 import * as Linux from './linux'
 
-export type ExternalEditor = Darwin.ExternalEditor | Win32.ExternalEditor
+export type ExternalEditor =
+  | Darwin.ExternalEditor
+  | Win32.ExternalEditor
+  | Linux.ExternalEditor
 
 /** Parse the label into the specified shell type. */
 export function parse(label: string): ExternalEditor | null {

--- a/app/src/lib/shells/linux.ts
+++ b/app/src/lib/shells/linux.ts
@@ -13,6 +13,7 @@ export enum Shell {
   Xterm = 'XTerm',
   Terminology = 'Terminology',
   Deepin = 'Deepin Terminal',
+  Elementary = 'Elementary Terminal',
 }
 
 export const Default = Shell.Gnome
@@ -54,6 +55,10 @@ export function parse(label: string): Shell {
     return Shell.Deepin
   }
 
+  if (label === Shell.Elementary) {
+    return Shell.Elementary
+  }
+
   return Default
 }
 
@@ -81,6 +86,8 @@ function getShellPath(shell: Shell): Promise<string | null> {
       return getPathIfAvailable('/usr/bin/terminology')
     case Shell.Deepin:
       return getPathIfAvailable('/usr/bin/deepin-terminal')
+    case Shell.Elementary:
+      return getPathIfAvailable('/usr/bin/io.elementary.terminal')
     default:
       return assertNever(shell, `Unknown shell: ${shell}`)
   }
@@ -99,6 +106,7 @@ export async function getAvailableShells(): Promise<
     xtermPath,
     terminologyPath,
     deepinPath,
+    elementaryPath,
   ] = await Promise.all([
     getShellPath(Shell.Gnome),
     getShellPath(Shell.Mate),
@@ -109,6 +117,7 @@ export async function getAvailableShells(): Promise<
     getShellPath(Shell.Xterm),
     getShellPath(Shell.Terminology),
     getShellPath(Shell.Deepin),
+    getShellPath(Shell.Elementary),
   ])
 
   const shells: Array<IFoundShell<Shell>> = []
@@ -148,6 +157,10 @@ export async function getAvailableShells(): Promise<
     shells.push({ shell: Shell.Deepin, path: deepinPath })
   }
 
+  if (elementaryPath) {
+    shells.push({ shell: Shell.Elementary, path: elementaryPath })
+  }
+
   return shells
 }
 
@@ -171,6 +184,8 @@ export function launch(
     case Shell.Terminology:
       return spawn(foundShell.path, ['-d', path])
     case Shell.Deepin:
+      return spawn(foundShell.path, ['-w', path])
+    case Shell.Elementary:
       return spawn(foundShell.path, ['-w', path])
     default:
       return assertNever(shell, `Unknown shell: ${shell}`)

--- a/app/static/linux/github
+++ b/app/static/linux/github
@@ -17,7 +17,7 @@ fi
 if [ -f "$GITHUB_PATH/github-desktop-dev" ]; then
 	BINARY_NAME="github-desktop-dev"
 else
-  BINARY_NAME="github-desktop"
+	BINARY_NAME="github-desktop"
 fi
 
 ELECTRON="$GITHUB_PATH/$BINARY_NAME"

--- a/app/static/linux/github
+++ b/app/static/linux/github
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-if [ ! -L $0 ]; then
+if [ ! -L "$0" ]; then
 	# if path is not a symlink, find relatively
-	GITHUB_PATH="../../.$(dirname $0)"
+	GITHUB_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$0")")")")
 else
 	if command -v readlink >/dev/null; then
-		# if readlink exists, follow the symlink and find relatively
+		# if readlink exists, follow the symlink and then find relatively
 		SYMLINK=$(readlink -f "$0")
 		GITHUB_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$SYMLINK")")")")
 	else
@@ -13,7 +13,13 @@ else
 		GITHUB_PATH="/opt/GitHub Desktop"
 	fi
 fi
-BINARY_NAME="github-desktop"
+# check if this is a dev install or standard
+if [ -f "$GITHUB_PATH/github-desktop-dev" ]; then
+	BINARY_NAME="github-desktop-dev"
+else
+  BINARY_NAME="github-desktop"
+fi
+
 ELECTRON="$GITHUB_PATH/$BINARY_NAME"
 CLI="$GITHUB_PATH/resources/app/cli.js"
 

--- a/app/static/linux/github.sh
+++ b/app/static/linux/github.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+if [ ! -L $0 ]; then
+	# if path is not a symlink, find relatively
+	GITHUB_PATH="../../.$(dirname $0)"
+else
+	if command -v readlink >/dev/null; then
+		# if readlink exists, follow the symlink and find relatively
+		SYMLINK=$(readlink -f "$0")
+		GITHUB_PATH=$(dirname "$(dirname "$(dirname "$(dirname "$SYMLINK")")")")
+	else
+		# else use the standard install location
+		GITHUB_PATH="/opt/GitHub Desktop"
+	fi
+fi
+BINARY_NAME="github-desktop"
+ELECTRON="$GITHUB_PATH/$BINARY_NAME"
+CLI="$GITHUB_PATH/resources/app/cli.js"
+
+ELECTRON_RUN_AS_NODE=1 "$ELECTRON" "$CLI" "$@"
+
+exit $?

--- a/script/linux-after-install.sh
+++ b/script/linux-after-install.sh
@@ -5,14 +5,20 @@ set -e
 PROFILE_D_FILE="/etc/profile.d/github-desktop.sh"
 INSTALL_DIR="/opt/${productFilename}"
 CLI_DIR="$INSTALL_DIR/resources/app/static"
-SCRIPT=$"#!/bin/sh
-export PATH=\"$INSTALL_DIR:\$PATH\"
-export PATH=\"$CLI_DIR:\$PATH\""
 
 case "$1" in
     configure)
-      echo "$SCRIPT" > "${PROFILE_D_FILE}";
-      . "${PROFILE_D_FILE}";
+      # add executable permissions for CLI interface
+      chmod +x "$CLI_DIR"/github || :
+      # check if this is a dev install or standard
+      if [ -f "$INSTALL_DIR/github-desktop-dev" ]; then
+	      BINARY_NAME="github-desktop-dev"
+      else
+	      BINARY_NAME="github-desktop"
+      fi
+      # create symbolic links to /usr/bin directory
+      ln -f -s "$INSTALL_DIR"/$BINARY_NAME /usr/bin || :
+      ln -f -s "$CLI_DIR"/github /usr/bin || :
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/script/linux-after-install.sh
+++ b/script/linux-after-install.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 set -e
-productFilename="GitHub Desktop"
+
 PROFILE_D_FILE="/etc/profile.d/github-desktop.sh"
 INSTALL_DIR="/opt/${productFilename}"
 CLI_DIR="$INSTALL_DIR/resources/app/static"
-SCRIPT="#!/bin/sh
-export PATH=\"$INSTALL_DIR:$CLI_DIR:\$PATH\""
-
+SCRIPT=$"#!/bin/sh
+export PATH=\"$INSTALL_DIR:\$PATH\"
+export PATH=\"$CLI_DIR:\$PATH\""
 
 case "$1" in
     configure)

--- a/script/linux-after-install.sh
+++ b/script/linux-after-install.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
 set -e
-
+productFilename="GitHub Desktop"
 PROFILE_D_FILE="/etc/profile.d/github-desktop.sh"
 INSTALL_DIR="/opt/${productFilename}"
-SCRIPT=$"#!/bin/sh
-export PATH=\"$INSTALL_DIR:\$PATH\""
+CLI_DIR="$INSTALL_DIR/resources/app/static"
+SCRIPT="#!/bin/sh
+export PATH=\"$INSTALL_DIR:$CLI_DIR:\$PATH\""
+
 
 case "$1" in
     configure)

--- a/script/linux-after-remove.sh
+++ b/script/linux-after-remove.sh
@@ -8,6 +8,10 @@ case "$1" in
       echo "#!/bin/sh" > "${PROFILE_D_FILE}";
       . "${PROFILE_D_FILE}";
       rm "${PROFILE_D_FILE}";
+      # remove symbolic links in /usr/bin directory
+      unlink /usr/bin/github-desktop || :
+      unlink /usr/bin/github-desktop-dev || :
+      unlink /usr/bin/github || :
     ;;
 
     *)


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #32 

## Description

- Added github shim script to launch electron app from CLI
- Added check for linux environment to existing CLI file
- Adds static file directory to $PATH after install (to capture the github shim)
- BUGFIX: added check for linux-only editors
- Added Elementary Code as an editor as well as Elementary's Terminal
Tested in Elementary OS 5.1.2

### Screenshots

![image](https://user-images.githubusercontent.com/55799997/77005456-d0294880-692e-11ea-8615-039756a12c95.png)

## Release notes

- Added support for CLI for linux
- Added support for Elementary OS Terminal/Code

Notes:
