### PR TITLE
fix failing Windows tests

### DIFF
--- a/app/src/ui/lib/theme-change-monitor.ts
+++ b/app/src/ui/lib/theme-change-monitor.ts
@@ -11,11 +11,19 @@ class ThemeChangeMonitor implements IDisposable {
   }
 
   public dispose() {
+    if (remote.nativeTheme == null) {
+      return
+    }
+
     remote.nativeTheme.removeAllListeners()
   }
 
   private subscribe = () => {
     if (!supportsDarkMode()) {
+      return
+    }
+
+    if (remote.nativeTheme == null) {
       return
     }
 


### PR DESCRIPTION
Closes #227 

Not entirely sure why `remote.nativeTheme` may not be found from the renderer in these tests, but degrading in this situation to not detect theme changes seems fine.