### PR TITLE
revert using in-app menu and fallback to default window chrome

### DIFF
--- a/app/src/main-process/app-window.ts
+++ b/app/src/main-process/app-window.ts
@@ -53,7 +53,6 @@ export class AppWindow {
     } else if (__WIN32__) {
       windowOptions.frame = false
     } else if (__LINUX__) {
-      windowOptions.frame = false
       windowOptions.icon = path.join(__dirname, 'static', 'icon-logo.png')
 
       // relax restriction here for users trying to run app at a small

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1168,8 +1168,8 @@ export class App extends React.Component<IAppProps, IAppState> {
    * on Windows.
    */
   private renderAppMenuBar() {
-    // We render the app menu bar on Windows and Linux
-    if (__DARWIN__) {
+    // We only render the app menu bar on Windows
+    if (!__WIN32__) {
       return null
     }
 
@@ -1223,16 +1223,13 @@ export class App extends React.Component<IAppProps, IAppState> {
     // When we're in full-screen mode on Windows we only need to render
     // the title bar when the menu bar is active. On other platforms we
     // never render the title bar while in full-screen mode.
-
-    const appMenuPlatform = __WIN32__ || __LINUX__
-
     if (inFullScreen) {
-      if (!appMenuPlatform || !menuBarActive) {
+      if (!__WIN32__ || !menuBarActive) {
         return null
       }
     }
 
-    const showAppIcon = appMenuPlatform && !this.state.showWelcomeFlow
+    const showAppIcon = __WIN32__ && !this.state.showWelcomeFlow
     const inWelcomeFlow = this.state.showWelcomeFlow
     const inNoRepositoriesView = this.inNoRepositoriesViewState()
 

--- a/app/src/ui/window/title-bar.tsx
+++ b/app/src/ui/window/title-bar.tsx
@@ -84,11 +84,8 @@ export class TitleBar extends React.Component<ITitleBarProps, ITitleBarState> {
     const inFullScreen = this.props.windowState === 'full-screen'
     const isMaximized = this.props.windowState === 'maximized'
 
-    const appMenuPlatform = __WIN32__ || __LINUX__
-
     // No Windows controls when we're in full-screen mode.
-    const winControls =
-      appMenuPlatform && !inFullScreen ? <WindowControls /> : null
+    const winControls = __WIN32__ && !inFullScreen ? <WindowControls /> : null
 
     // On Windows it's not possible to resize a frameless window if the
     // element that sits flush along the window edge has -webkit-app-region: drag.

--- a/app/src/ui/window/window-controls.tsx
+++ b/app/src/ui/window/window-controls.tsx
@@ -97,8 +97,8 @@ export class WindowControls extends React.Component<{}, IWindowControlState> {
   }
 
   public render() {
-    // render the faux window controls for Windows and Linux builds
-    if (__DARWIN__) {
+    // We only know how to render fake Windows-y controls
+    if (!__WIN32__) {
       return <span />
     }
 

--- a/app/styles/mixins/_platform.scss
+++ b/app/styles/mixins/_platform.scss
@@ -41,25 +41,3 @@
     @content;
   }
 }
-
-// A mixin which takes a content block that should only
-// be applied when the current (real or emulated) operating
-// system is Linux.
-//
-// This helper mixin is useful in so far that it allows us
-// to keep platform specific styles next to cross-platform
-// styles instead of splitting them out and possibly forgetting
-// about them.
-@mixin linux {
-  body.platform-linux & {
-    @content;
-  }
-}
-
-// An exact copy of the linux mixin except that it allows for
-// writing base-level rules
-@mixin linux-context {
-  body.platform-linux {
-    @content;
-  }
-}

--- a/app/styles/ui/window/_title-bar.scss
+++ b/app/styles/ui/window/_title-bar.scss
@@ -27,18 +27,6 @@
     }
   }
 
-  @include linux {
-    height: var(--win32-title-bar-height);
-    background: var(--win32-title-bar-background-color);
-    border-bottom: 1px solid #000;
-
-    .app-icon {
-      color: var(--toolbar-button-secondary-color);
-      margin: 0 var(--spacing);
-      align-self: center;
-    }
-  }
-
   .resize-handle {
     position: absolute;
     top: 0px;


### PR DESCRIPTION
Reverts #139 
Resolves #149 

 - [x] test locally and confirm menu works as expected
 - [x] add screenshot of current chrome in default Ubuntu (with light and dark theme set)
 - [x] rebase `linux` to drop original commit from future releases
 - [x] merge PR to re-add scaffolding for mixins needed scrollbar styling - #247 

### Light theme

![](https://user-images.githubusercontent.com/359239/77830403-e8574f80-7106-11ea-9c78-eac7d248554d.png)

### Dark theme

![](https://user-images.githubusercontent.com/359239/77830399-e4c3c880-7106-11ea-9a11-4906a3f54e6d.png)

I'd like to get some feedback from users that this is their desired behaviour, so please 👍 or 👎 this PR to confirm this is what you prefer. I plan to leave this open until April 11 to ensure everyone has a chance to review this.