### PR TITLE
Detach CLI process from terminal

### DIFF
--- a/app/static/linux/github
+++ b/app/static/linux/github
@@ -23,6 +23,13 @@ fi
 ELECTRON="$GITHUB_PATH/$BINARY_NAME"
 CLI="$GITHUB_PATH/resources/app/cli.js"
 
-ELECTRON_RUN_AS_NODE=1 "$ELECTRON" "$CLI" "$@" </dev/null &>/dev/null &
+case $1 in
+  # if help in the first variable, return contents to shell
+	*help*|*--help*)
+		ELECTRON_RUN_AS_NODE=1 "$ELECTRON" "$CLI" "$@";;
+	# any other, redirect to /dev/null to detach from controlling terminal
+	*)
+		ELECTRON_RUN_AS_NODE=1 "$ELECTRON" "$CLI" "$@" < /dev/null > /dev/null &;;
+esac
 
 exit $?

--- a/app/static/linux/github
+++ b/app/static/linux/github
@@ -23,6 +23,6 @@ fi
 ELECTRON="$GITHUB_PATH/$BINARY_NAME"
 CLI="$GITHUB_PATH/resources/app/cli.js"
 
-ELECTRON_RUN_AS_NODE=1 "$ELECTRON" "$CLI" "$@"
+ELECTRON_RUN_AS_NODE=1 "$ELECTRON" "$CLI" "$@" </dev/null &>/dev/null &
 
 exit $?

--- a/app/static/linux/github
+++ b/app/static/linux/github
@@ -24,7 +24,7 @@ ELECTRON="$GITHUB_PATH/$BINARY_NAME"
 CLI="$GITHUB_PATH/resources/app/cli.js"
 
 case $1 in
-  # if help in the first variable, return contents to shell
+	# if help in the first variable, return contents to shell
 	*help*|*--help*)
 		ELECTRON_RUN_AS_NODE=1 "$ELECTRON" "$CLI" "$@";;
 	# any other, redirect to /dev/null to detach from controlling terminal


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #238 

## Description

Added /dev/null to end of electron CLI command to detach requests from the controlling terminal upon execution

## Release notes

Notes: no-notes
