### PR TITLE
Linux About Modal

### DIFF
--- a/app/src/ui/about/about.tsx
+++ b/app/src/ui/about/about.tsx
@@ -15,6 +15,7 @@ import { Loading } from '../lib/loading'
 import { RelativeTime } from '../relative-time'
 import { assertNever } from '../../lib/fatal-error'
 import { ReleaseNotesUri } from '../lib/releases'
+import { LinuxReleasesUri } from '../lib/releases'
 import { encodePathAsUrl } from '../../lib/path'
 
 const DesktopLogo = encodePathAsUrl(__dirname, 'static/logo-64x64@2x.png')
@@ -94,6 +95,17 @@ export class About extends React.Component<IAboutProps, IAboutState> {
       return null
     }
 
+    if (__LINUX__) {
+      const linuxReleaseLink = (
+        <LinkButton uri={LinuxReleasesUri}>View Linux Releases</LinkButton>
+      )
+      return (
+        <Row>
+          <p className="no-padding">{linuxReleaseLink}</p>
+        </Row>
+      )
+    }
+
     const updateStatus = this.state.updateState.status
 
     switch (updateStatus) {
@@ -169,7 +181,12 @@ export class About extends React.Component<IAboutProps, IAboutState> {
 
   private renderUpdateDetails() {
     if (__LINUX__) {
-      return null
+      return (
+        <p>
+          Please visit the GitHub Desktop for Linux release page for
+          Linux-specific release notes and to download the latest version.
+        </p>
+      )
     }
 
     if (

--- a/app/src/ui/about/about.tsx
+++ b/app/src/ui/about/about.tsx
@@ -14,8 +14,7 @@ import { Disposable } from 'event-kit'
 import { Loading } from '../lib/loading'
 import { RelativeTime } from '../relative-time'
 import { assertNever } from '../../lib/fatal-error'
-import { ReleaseNotesUri } from '../lib/releases'
-import { LinuxReleasesUri } from '../lib/releases'
+import { ReleaseNotesUri, LinuxReleasesUri } from '../lib/releases'
 import { encodePathAsUrl } from '../../lib/path'
 
 const DesktopLogo = encodePathAsUrl(__dirname, 'static/logo-64x64@2x.png')
@@ -97,7 +96,7 @@ export class About extends React.Component<IAboutProps, IAboutState> {
 
     if (__LINUX__) {
       const linuxReleaseLink = (
-        <LinkButton uri={LinuxReleasesUri}>View Linux Releases</LinkButton>
+        <LinkButton uri={LinuxReleasesUri}>View Releases</LinkButton>
       )
       return (
         <Row>

--- a/app/src/ui/lib/releases.ts
+++ b/app/src/ui/lib/releases.ts
@@ -1,1 +1,2 @@
 export const ReleaseNotesUri = 'https://desktop.github.com/release-notes/'
+export const LinuxReleasesUri = 'https://github.com/shiftkey/desktop/releases/'


### PR DESCRIPTION
## Description

Updated the "About GitHub Desktop" model to remove the button to check for updates (since it didn't do anything on Linux) and replaced with a link to the linux releases page

### Screenshots

![image](https://user-images.githubusercontent.com/55799997/77884732-44b38f80-722b-11ea-90a5-af7f6da323a1.png)

## Release notes

Notes: Removed the 'check for updates' button, and replaced with a link to the unofficial linux releases page.
