### PR TITLE
[WIP] attempt a windows build using Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,16 +1,16 @@
 name: CI
 on:
   push:
-    branches: [ linux ]
+    branches: [linux]
   pull_request:
-    branches: [ linux ]
+    branches: [linux]
 
 jobs:
   build:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
-    - run: yarn install --force
-    - run: yarn build:prod
-    - run: yarn test:setup && yarn test
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+      - run: yarn install --force
+      - run: yarn build:prod
+      - run: yarn test:setup && yarn test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v1
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
       - run: yarn install --force
       - run: yarn build:prod
       - run: yarn test:setup && yarn test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,16 @@
+name: CI
+on:
+  push:
+    branches: [ linux ]
+  pull_request:
+    branches: [ linux ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+    - run: yarn install --force
+    - run: yarn build:prod
+    - run: yarn test:setup && yarn test


### PR DESCRIPTION
Azure Pipelines has been nice but I'd like to see how much of it I can emulate using Actions so things are all derived from this single repository:

 - build and test `linux` as well as any PR targeting `linux`
 - caching of packages to speed up build
 - packaging artifacts (Linux only)
 - generating a release when the tag gets published
 - other distribution channels

I'd eventually like to get away from the Docker-based shenanigans I've setup on Pipelines, but that only impacts packaging for Linux. 