### PR TITLE
restore mixing to support custom styles targeting Linux

### DIFF
--- a/app/styles/mixins/_platform.scss
+++ b/app/styles/mixins/_platform.scss
@@ -41,3 +41,25 @@
     @content;
   }
 }
+
+// A mixin which takes a content block that should only
+// be applied when the current (real or emulated) operating
+// system is Linux.
+//
+// This helper mixin is useful in so far that it allows us
+// to keep platform specific styles next to cross-platform
+// styles instead of splitting them out and possibly forgetting
+// about them.
+@mixin linux {
+  body.platform-linux & {
+    @content;
+  }
+}
+
+// An exact copy of the linux mixin except that it allows for
+// writing base-level rules
+@mixin linux-context {
+  body.platform-linux {
+    @content;
+  }
+}


### PR DESCRIPTION
With #139 removed from the `linux` branch, this will no longer build and emit an error like this in the output:

```
[WEBPACK] Errors building crash.js
Module build failed: ModuleBuildError: Module build failed: 
@include linux-context {
        ^
      No mixin named linux-context
      in /home/shiftkey/src/desktop/app/styles/ui/_scroll.scss (line 63, column 10)
    at /home/shiftkey/src/desktop/node_modules/webpack/lib/NormalModule.js:252:20
    at /home/shiftkey/src/desktop/node_modules/loader-runner/lib/LoaderRunner.js:364:11
    at /home/shiftkey/src/desktop/node_modules/loader-runner/lib/LoaderRunner.js:230:18
    at context.callback (/home/shiftkey/src/desktop/node_modules/loader-runner/lib/LoaderRunner.js:111:13)
    at Object.callback (/home/shiftkey/src/desktop/node_modules/sass-loader/lib/loader.js:76:13)
    at Object.done [as callback] (/home/shiftkey/src/desktop/node_modules/neo-async/async.js:8067:18)
    at options.error (/home/shiftkey/src/desktop/node_modules/node-sass/lib/index.js:294:32)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

This commit should fix the build and enable the work #240 to work again in the main branch. 

 - [x] test locally and confirm scrollbar styles are applied to dark theme
 - [x] wait on upstream issues with CI and installing NodeJS 