### PR TITLE
set filemode for chrome-sandbox executable during package

### DIFF
--- a/script/package.ts
+++ b/script/package.ts
@@ -177,6 +177,14 @@ function generateChecksums() {
 }
 
 function packageLinux() {
+  const helperPath = path.join(getDistPath(), 'chrome-sandbox')
+  const exists = fs.pathExistsSync(helperPath)
+
+  if (exists) {
+    console.log('Updating file mode for chrome-sandbox…')
+    fs.chmodSync(helperPath, 0o4755)
+  }
+
   const electronBuilder = path.resolve(
     __dirname,
     '..',


### PR DESCRIPTION
A partial fix for #222, but as we've uncovered in that issue the full fix requires:

 - `sudo sysctl kernel.unprivileged_userns_clone=1` to enable unprivileged user namespaces (specifically disabled in Debian and other distros), or
 - passing `--no-sandbox` when launching the app (which effectively disables some of Chromium's security features)

This change will be applied for both deb and rpm packages, but I think it's low risk. Will verify in a test at some stage.

 - [x] test RPM on Fedora and confirm defaults work as expected