### PR TITLE
SUID workaround

### DIFF
--- a/script/linux-after-remove.sh
+++ b/script/linux-after-remove.sh
@@ -2,6 +2,7 @@
 set -e
 
 PROFILE_D_FILE="/etc/profile.d/github-desktop.sh"
+BASE_FILE="/usr/bin/github"
 
 case "$1" in
     purge|remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
@@ -9,9 +10,9 @@ case "$1" in
       . "${PROFILE_D_FILE}";
       rm "${PROFILE_D_FILE}";
       # remove symbolic links in /usr/bin directory
-      unlink /usr/bin/github-desktop || :
-      unlink /usr/bin/github-desktop-dev || :
-      unlink /usr/bin/github || :
+      test -f ${BASE_FILE} && unlink ${BASE_FILE}
+      test -f ${BASE_FILE}-desktop && unlink ${BASE_FILE}-desktop
+      test -f ${BASE_FILE}-desktop-dev && unlink ${BASE_FILE}-desktop-dev
     ;;
 
     *)

--- a/script/run.ts
+++ b/script/run.ts
@@ -43,3 +43,25 @@ export function run(spawnOptions: SpawnOptions) {
 
   return spawn(binaryPath, [], opts)
 }
+
+// fallback workaround for hardened linux kernel, especially Debian 10
+
+export function runNoSandbox(spawnOptions: SpawnOptions) {
+  try {
+    // eslint-disable-next-line no-sync
+    const stats = Fs.statSync(binaryPath)
+    if (!stats.isFile()) {
+      return null
+    }
+  } catch (e) {
+    return null
+  }
+
+  const opts = Object.assign({}, spawnOptions)
+
+  opts.env = Object.assign(opts.env || {}, process.env, {
+    NODE_ENV: 'development',
+  })
+
+  return spawn(binaryPath, ['--no-sandbox'], opts)
+}


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Workaround for  #222

## Description

If the client exits upon start, it will automatically attempt to re-launch with the `--no-sandbox` tag as an attempt to address the SUID issue with Debian 10 and similar.  This is a workaround to prefer automatically running the client instead of appearing to not work pending user intervention.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

![image](https://user-images.githubusercontent.com/55799997/79323597-0927ef00-7ed4-11ea-85d9-1ea9d8a05a5d.png)


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
