### PR TITLE
move lint job out to standalone Action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,34 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - linux
+      - 'linux-release-*'
+    tags:
+      - 'release-*.*.*-linux*'
+  pull_request:
+    branches:
+      - linux
+      - 'linux-release-*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v1
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - run: yarn
+        env:
+          CI: true
+      - run: yarn lint
+      - run: yarn check-modified

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -145,26 +145,3 @@ jobs:
           codeCoverageTool: 'cobertura'
           summaryFileLocation: '**/app/coverage/cobertura-coverage.xml'
         condition: always()
-
-  - job: Lint
-    pool:
-      vmImage: ubuntu-16.04
-    steps:
-      - script: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libsecret-1-dev
-      - task: NodeTool@0
-        inputs:
-          versionSpec: '10.17.x'
-      - task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@2
-        inputs:
-          versionSpec: '1.5.1'
-      - script: |
-          yarn install --force
-        name: Install
-      - script: |
-          yarn lint
-        name: Lint
-      - script: |
-          yarn check-modified
-        displayName: 'Check for modified files'


### PR DESCRIPTION
I'd like to see how feasible it is to be using Actions for generating releases, but for now I'd like to simplify our Azure Pipelines config by extracting out some of the stable parts into their own build steps.

First off, the lint task.

 - [x] confirm task works
 - [x] review syntax for tag matching
 - [x] remove section from Pipelines config
 - [x] enable cache plugin