### PR TITLE
userns check

### DIFF
--- a/app/static/linux/github-launch.sh
+++ b/app/static/linux/github-launch.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+# Check setting
+USERNS_SETTING=$(eval "sysctl -n kernel.unprivileged_userns_clone")
+
+if [ "$USERNS_SETTING" = 1 ]; then
+    # Your kernel has the patch to allow unprivileged user namespace
+    FLAG=""
+elif [ "$USERNS_SETTING" = 0 ]; then
+    # Your kernel has unprivileged user namespace disabled
+    echo "User namespaces are not detected as enabled on your system, GitHub will run with the sandbox disabled"
+    FLAG="--no-sandbox"
+else
+    # We need a new test
+    echo "Unknown user namespace setting; running as normal"
+    FLAG=""
+fi
+
+# Warn the user if sandboxing will be turned off, otherwise just attempt to run
+if [ $FLAG ]; then
+    zenity \
+    --question \
+    --text="<span size=\"xx-large\">Unable to enable sandbox.</span> \
+\n\nUser namespaces are not detected as enabled on your system.\n\
+Run GitHub Desktop with sandbox <b>disabled</b>?" \
+    --icon-name="dialog-warning" \
+    --no-wrap \
+    --title="GitHub Desktop" \
+    --ok-label="Launch" \
+    --cancel-label="Cancel"
+
+    if [ $? = 0 ]; then
+        exec github-desktop $@ $FLAG
+    fi
+else 
+    exec github-desktop $@
+fi

--- a/script/electron-builder-linux.yml
+++ b/script/electron-builder-linux.yml
@@ -11,6 +11,7 @@ linux:
     - rpm
     - AppImage
   maintainer: 'GitHub, Inc <opensource+desktop@github.com>'
+  executableName: 'github-launch'
 deb:
   afterInstall: './script/linux-after-install.sh'
   afterRemove: './script/linux-after-remove.sh'

--- a/script/package.ts
+++ b/script/package.ts
@@ -183,6 +183,16 @@ function packageLinux() {
   if (exists) {
     console.log('Updating file mode for chrome-sandbox…')
     fs.chmodSync(helperPath, 0o4755)
+    const launchPath = path.join(
+      getDistPath(),
+      'resources/app/static/github-launch.sh'
+    )
+    if (fs.pathExistsSync(launchPath)) {
+      const symlink = path.join(getDistPath(), 'github-launch')
+      fs.chmodSync(launchPath, 0o775)
+      fs.symlinkSync(launchPath, symlink)
+      console.log('The permissions for github-launch have been changed')
+    }
   }
 
   const electronBuilder = path.resolve(


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #222 

## Description

Check for userns prior to launching github desktop, allow user to choose to run with sandbox disabled

### Screenshots

![image](https://user-images.githubusercontent.com/55799997/79632463-f9ebb000-8124-11ea-8fb9-8601fe78bac9.png)

## Release notes

Notes: Added prelaunch script to allow a check for user namespace and potentially other future checks
