### PR TITLE
handle deprecated Electron warnings

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -444,7 +444,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const window = remote.getCurrentWindow()
     this.windowState = getWindowState(window)
 
-    this.onWindowZoomFactorChanged(window.webContents.getZoomFactor())
+    this.onWindowZoomFactorChanged(window.webContents.zoomFactor)
 
     this.wireupIpcEventHandlers(window)
     this.wireupStoreEventHandlers()

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -619,11 +619,11 @@ function zoom(direction: ZoomDirection): ClickHandler {
       webContents.setZoomFactor(1)
       webContents.send('zoom-factor-changed', 1)
     } else {
-      const rawZoom = webContents.getZoomFactor()
+      const rawZoom = webContents.zoomFactor
       const zoomFactors =
         direction === ZoomDirection.In ? ZoomInFactors : ZoomOutFactors
 
-      // So the values that we get from getZoomFactor are floating point
+      // So the values that we get from zoomFactor are floating point
       // precision numbers from chromium that don't always round nicely so
       // we'll have to do a little trick to figure out which of our supported
       // zoom factors the value is referring to.

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -616,7 +616,7 @@ function zoom(direction: ZoomDirection): ClickHandler {
     const { webContents } = window
 
     if (direction === ZoomDirection.Reset) {
-      webContents.setZoomFactor(1)
+      webContents.zoomFactor = 1
       webContents.send('zoom-factor-changed', 1)
     } else {
       const rawZoom = webContents.zoomFactor
@@ -638,7 +638,7 @@ function zoom(direction: ZoomDirection): ClickHandler {
       // factor we've got.
       const newZoom = nextZoomLevel === undefined ? currentZoom : nextZoomLevel
 
-      webContents.setZoomFactor(newZoom)
+      webContents.zoomFactor = newZoom
       webContents.send('zoom-factor-changed', newZoom)
     }
   }

--- a/app/src/ui/lib/app-proxy.ts
+++ b/app/src/ui/lib/app-proxy.ts
@@ -35,7 +35,7 @@ export function getVersion(): string {
  */
 export function getName(): string {
   if (!name) {
-    name = getApp().getName()
+    name = getApp().name
   }
 
   return name

--- a/app/test/__mocks__/electron.ts
+++ b/app/test/__mocks__/electron.ts
@@ -9,7 +9,7 @@ export const remote = {
   getCurrentWindow: jest.fn().mockImplementation(() => ({
     isFullScreen: jest.fn().mockImplementation(() => true),
     webContents: {
-      getZoomFactor: jest.fn().mockImplementation(_ => null),
+      zoomFactor: jest.fn().mockImplementation(_ => null),
     },
   })),
   autoUpdater: {


### PR DESCRIPTION
This PR addresses some warnings that Electron emits to the terminal about API deprecations:

 - [x] `getZoomFactor` -> `zoomFactor`
 - [x] `setZoomFactor` -> `zoomFactor` ???
 - [x] `getName` -> `name`
 - [x] test locally and confirm zooming works as expected