### PR TITLE
add simpler packaging dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/script/docker/packaging.Dockerfile
+++ b/script/docker/packaging.Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:focal
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt -qq update
+RUN apt -qq install --yes curl gnupg
+
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+
+# add custom tools required for electron-builder
+RUN apt -qq update
+RUN apt -qq install --yes \
+  nodejs \
+  yarn \
+  # needed for pacman builds
+  libarchive-tools \
+  # needed for RPM builds
+  rpm \
+  # needed for deb builds using fpm
+  binutils \
+  # needed for electron-installer-debian
+  dpkg \
+  fakeroot \
+  # needed for tweaking Snap output post-packaging
+  squashfs-tools


### PR DESCRIPTION
This adds a simpler Docker image using the latest LTS and similar packaging tools necessary to build things, without being dependent on `snapcore/snapcraft`.