### PR TITLE
[RPM] make libcurl4 an optional requirement

### DIFF
--- a/script/package-redhat.ts
+++ b/script/package-redhat.ts
@@ -47,7 +47,7 @@ const options: RedhatOptions = {
     'libX11-xcb',
     'alsa-lib',
     // dugite-native dependencies
-    'libcurl',
+    '(libcurl or libcurl4)',
     // keytar dependencies
     'libsecret',
     'gnome-keyring',


### PR DESCRIPTION
Resolves #312 

Supersedes #314 