### PR TITLE
allow tilde character when specifying a local repository

### DIFF
--- a/app/src/ui/add-repository/add-existing-repository.tsx
+++ b/app/src/ui/add-repository/add-existing-repository.tsx
@@ -165,7 +165,7 @@ export class AddExistingRepository extends React.Component<
   }
 
   private onPathChanged = async (path: string) => {
-    const isRepository = await isGitRepository(path)
+    const isRepository = await isGitRepository(this.resolvedPath(path))
 
     this.setState({ path, isRepository })
   }


### PR DESCRIPTION
**Fixes #294**

## Description

- Uses resolved path (which uses untildify to convert our path into an absolute path) when checking if the path is a git repository so that it will find the repository path and validate correctly.
___
### Screenshots
![image](https://user-images.githubusercontent.com/4957200/88879513-0e454b80-d1f0-11ea-823d-ad6fe4914768.png)
___
### Notes:
On the original issue there was discussion about potential concerns on why this functionality already existed but was not being used on the `onPathChanged` function.

Upon looking into the git history, this is what I found:
- [This commit](https://github.com/desktop/desktop/commit/fc08ecb62985e6fe436e694527dd295a50099ef2#diff-6dae3894c6f307fe7c0fbccef6678fb1R65-R71) introduced `untildify` to the `checkIfPathIsRepository` function, feeding the absolute path to `isGitRepository`.
- This series of commits moved this functionality into the resolvedPath function we have today. [[1](https://github.com/desktop/desktop/commit/cbe174e659e9570528f0268ed730f74e9d715ce2)][[2](https://github.com/desktop/desktop/commit/869e88384315432b017b22f9071acd59aa61cceb)][[3](https://github.com/desktop/desktop/commit/4d0397b04d31719007415f572eb70ec98c3a66af)]
- [This commit](https://github.com/desktop/desktop/commit/418b4be06e2dcc88b425646264a20fb563e2e71b#diff-6dae3894c6f307fe7c0fbccef6678fb1L119-L133) removed the `checkIfPathIsRepository` function that included the resolvedPath call that was used, and introduced the `isGitRepository` function directly to the `onPathChanged` function, thus losing our home path support.

It appears to me that this change was unintentional, and not part of a testing issue. I have been able to check that the change is working as expected on my linux installation, and would love to test and make sure it works as intended on Windows soon.
___
