### PR TITLE
refine checks for when running in a fork on GitHub Actions

### DIFF
--- a/script/build-platforms.ts
+++ b/script/build-platforms.ts
@@ -63,12 +63,20 @@ export function isRunningOnFork() {
     return true
   }
 
-  if (
-    isGitHubActions() &&
-    process.env.GITHUB_HEAD_REF !== undefined &&
-    process.env.GITHUB_HEAD_REF.length > 0
-  ) {
-    return true
+  if (isGitHubActions()) {
+    if (
+      process.env.GITHUB_EVENT_NAME === 'push' &&
+      process.env.GITHUB_REPOSITORY !== 'desktop/desktop'
+    ) {
+      return true
+    } else if (
+      process.env.GITHUB_EVENT_NAME === 'pull_request' &&
+      process.env.GITHUB_REPOSITORY !== 'desktop/desktop' &&
+      process.env.GITHUB_HEAD_REF !== undefined &&
+      process.env.GITHUB_HEAD_REF.length > 0
+    ) {
+      return true
+    }
   }
 
   return false

--- a/script/build-platforms.ts
+++ b/script/build-platforms.ts
@@ -68,6 +68,9 @@ export function isRunningOnFork() {
       process.env.GITHUB_EVENT_NAME === 'push' &&
       process.env.GITHUB_REPOSITORY !== 'desktop/desktop'
     ) {
+      console.log(
+        `Found push event for repository '${process.env.GITHUB_REPOSITORY}' which is considered a fork`
+      )
       return true
     } else if (
       process.env.GITHUB_EVENT_NAME === 'pull_request' &&
@@ -75,6 +78,9 @@ export function isRunningOnFork() {
       process.env.GITHUB_HEAD_REF !== undefined &&
       process.env.GITHUB_HEAD_REF.length > 0
     ) {
+      console.log(
+        `Found head ref '${process.env.GITHUB_HEAD_REF}' for repository '${process.env.GITHUB_REPOSITORY}' which is considered a fork`
+      )
       return true
     }
   }


### PR DESCRIPTION
Investigating an upstream patch around detecting whether this action is running on a forked repository

 - [x] confirm `pull_request` event has correct context for PR in this fork
 - [x] confirm `push` event has correct context in this fork (will run after merge)