### PR TITLE
Remove deprecated apt-key from installation setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ the project using the link in the header.
 To setup the package repository, run these commands:
 
 ```sh
-$ wget -qO - https://packagecloud.io/shiftkey/desktop/gpgkey | sudo apt-key add -
+$ wget -qO - https://packagecloud.io/shiftkey/desktop/gpgkey | sudo tee /etc/apt/trusted.gpg.d/shiftkey-desktop.asc > /dev/null
 $ sudo sh -c 'echo "deb [arch=amd64] https://packagecloud.io/shiftkey/desktop/any/ any main" > /etc/apt/sources.list.d/packagecloud-shiftky-desktop.list'
 $ sudo apt-get update
 ```


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #353

## Description

- This pull request removes deprecated apt-key from installation setup

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->
Removed deprecated apt-key usage in Debian/Ubuntu distributions installation setup .