### PR TITLE
add optional x11 dependency for SUSE-based distributions

### DIFF
--- a/script/package-redhat.ts
+++ b/script/package-redhat.ts
@@ -44,7 +44,7 @@ const options: RedhatOptions = {
   requires: [
     // default Electron dependencies
     'libXScrnSaver',
-    'libX11-xcb',
+    '(libX11-xcb or libX11-xcb1)',
     'alsa-lib',
     // dugite-native dependencies
     '(libcurl or libcurl4)',


### PR DESCRIPTION
Closes #322

## Description

- Adds support for different package for Xlib/XCB interface library which is available on SUSE-based distributions

## Release notes

Notes: Adds support for different package for Xlib/XCB interface library which is available on SUSE-based distributions
