### PR TITLE
hide appbar component on Linux

### DIFF
--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1203,6 +1203,12 @@ export class App extends React.Component<IAppProps, IAppState> {
       this.state.currentFoldout &&
       this.state.currentFoldout.type === FoldoutType.AppMenu
 
+    // As Linux still uses the classic Electron menu, we are opting out of the
+    // custom menu that is shown as part of the title bar below
+    if (__LINUX__) {
+      return null
+    }
+
     // When we're in full-screen mode on Windows we only need to render
     // the title bar when the menu bar is active. On other platforms we
     // never render the title bar while in full-screen mode.


### PR DESCRIPTION
A small visual regression I noticed in the latest update - the empty app bar is being rendered again, despite being disabled on Linux for a while.

There might be a better place to fix this, but for now I'm going to pull this into a new update.

### Current release
![](https://user-images.githubusercontent.com/359239/102627449-989a3780-411e-11eb-95cd-2f9d3c39c285.png)

### This PR

![](https://user-images.githubusercontent.com/359239/102627453-9932ce00-411e-11eb-997c-4f008e148406.png)

