### PR TITLE
bump dockerfiles to Node 14

### DIFF
--- a/script/docker/packaging.Dockerfile
+++ b/script/docker/packaging.Dockerfile
@@ -5,7 +5,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt -qq update
 RUN apt -qq install --yes curl gnupg
 
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+RUN curl -fsSL https://deb.nodesource.com/setup_14.x  | bash -
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 

--- a/script/docker/snapcraft.Dockerfile
+++ b/script/docker/snapcraft.Dockerfile
@@ -3,7 +3,7 @@ FROM snapcore/snapcraft
 RUN apt -qq update
 RUN apt -qq install --yes curl gnupg
 
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+RUN curl -fsSL https://deb.nodesource.com/setup_14.x | bash -
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 

--- a/script/docker/trusty.Dockerfile
+++ b/script/docker/trusty.Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get install --quiet --yes \
 RUN add-apt-repository ppa:git-core/ppa
 
 # install the latest LTS version of Node
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+RUN curl -fsSL https://deb.nodesource.com/setup_14.x | bash -
 
 # install the latest version of Yarn
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -


### PR DESCRIPTION
Upstream is now using Node 14 to build, so this ensures Azure Pipelines is on the same version