### PR TITLE
perform packaging steps on Linux build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,13 @@ jobs:
       fail-fast: false
       matrix:
         node: [14.x]
-        os: [macos-10.15, windows-2019, ubuntu-20.04]
+        os: [macos-10.15, windows-2019, ubuntu-18.04]
         include:
           - os: macos-10.15
             friendlyName: macOS
           - os: windows-2019
             friendlyName: Windows
-          - os: ubuntu-20.04
+          - os: ubuntu-18.04
             friendlyName: Ubuntu
     timeout-minutes: 45
     steps:
@@ -69,3 +69,21 @@ jobs:
       - name: Run integration tests
         timeout-minutes: 5
         run: yarn test:integration
+      - name: Package application
+        run: yarn run package
+        if: ${{ matrix.os == 'ubuntu-18.04' }}
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        if:
+          ${{ matrix.os == 'ubuntu-18.04' && startsWith(github.ref,
+          'refs/tags/') }}
+        with:
+          files: |
+            dist/*.AppImage
+            dist/*.deb
+            dist/*.rpm
+            dist/*.txt
+          draft: true
+          prerelease: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I can't figure out why Azure Pipelines is displeased with the Electron 11 upgrade, so this PR digs into creating the installers and publishing them to a GitHub release - basically what I was doing before, but now with some better automation:

  - [x] build and package app using `ubuntu-18.04` (a bump from `16.04` due to `rpm` `4.13` not being available)
 - [x] add steps to create draft and prerelease release (runs when tag found)
 - [x] switch off docker hub and VSO integration 

### Future work

 - cleanup azure-pipelines config and docker files
 - generate release notes using changelog, checksums and other tools and set as `body_path` parameter
 - figure out how to add [`shiftkey/publish-desktop-to-packagecloud`](https://github.com/shiftkey/publish-desktop-to-packagecloud) as action in follow-up step