### PR TITLE
port jest setup to use new parameters

### DIFF
--- a/app/jest.integration.config.js
+++ b/app/jest.integration.config.js
@@ -5,7 +5,7 @@ module.exports = {
   },
   testMatch: ['**/integration/**/*-test.ts{,x}'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
-  setupTestFrameworkScriptFile: '<rootDir>/test/setup-test-framework.ts',
+  setupFilesAfterEnv: ['<rootDir>/test/setup-test-framework.ts'],
   reporters: ['default', '<rootDir>../script/jest-actions-reporter.js'],
   globals: {
     'ts-jest': {

--- a/app/jest.unit.config.js
+++ b/app/jest.unit.config.js
@@ -6,7 +6,7 @@ module.exports = {
   testMatch: ['**/unit/**/*-test.ts{,x}'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   setupFiles: ['<rootDir>/test/globals.ts', '<rootDir>/test/unit-test-env.ts'],
-  setupTestFrameworkScriptFile: '<rootDir>/test/setup-test-framework.ts',
+  setupFilesAfterEnv: ['<rootDir>/test/setup-test-framework.ts'],
   collectCoverageFrom: [
     'src/**/*.{js,jsx,ts,tsx}',
     '!**/node_modules/**',


### PR DESCRIPTION
Addresses these deprecations that currently pop up while running `yarn test` (and others):

```
$ yarn run v1.21.1
$ yarn test:unit:cov --runInBand && yarn test:script:cov && yarn test:integration
$ yarn test:unit --coverage --runInBand
$ cross-env ELECTRON_RUN_AS_NODE=1 ./node_modules/.bin/electron ./node_modules/jest/bin/jest --detectOpenHandles --silent --testLocationInResults --config ./app/jest.unit.config.js --coverage --runInBand
● Deprecation Warning:

  Option "setupTestFrameworkScriptFile" was replaced by configuration "setupFilesAfterEnv", which supports multiple paths.

  Please update your configuration.

  Configuration Documentation:
  https://jestjs.io/docs/configuration.html

● Deprecation Warning:

  Option "setupTestFrameworkScriptFile" was replaced by configuration "setupFilesAfterEnv", which supports multiple paths.

  Please update your configuration.

  Configuration Documentation:
  https://jestjs.io/docs/configuration.html

...
```