### PR TITLE
Updated linux.ts new alternate path vs code

### DIFF
--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -22,7 +22,7 @@ const editors: ILinuxExternalEditor[] = [
   },
   {
     name: 'Visual Studio Code',
-    paths: ['/snap/bin/code', '/usr/bin/code'],
+    paths: ['/usr/share/code/code', '/snap/bin/code', '/usr/bin/code'],
   },
   {
     name: 'Visual Studio Code (Insiders)',


### PR DESCRIPTION
After updating the VS Code via Pop Shop of Pop!_OS Linux, the VS Code is in another location on the hard drive. That is why github desktop does not recognize the editor. So, I add this new path, in the linux.ts file, correcting the error.

Closes #443