### PR TITLE
Fix path to VS Code in Pop!_OS

### DIFF
--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -22,7 +22,7 @@ const editors: ILinuxExternalEditor[] = [
   },
   {
     name: 'Visual Studio Code',
-    paths: ['/usr/share/code/code', '/snap/bin/code', '/usr/bin/code'],
+    paths: ['/usr/share/code/bin/code', '/snap/bin/code', '/usr/bin/code'],
   },
   {
     name: 'Visual Studio Code (Insiders)',


### PR DESCRIPTION
Fix path to bin directory to VS Code in Pop!_OS

<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #443

## Description

- Fix path to correct script to VS Code in `bin` directory in Pop!_OS.