### PR TITLE
add missing MIME type to AppImage package

### DIFF
--- a/script/electron-builder-linux.yml
+++ b/script/electron-builder-linux.yml
@@ -6,9 +6,9 @@ linux:
   mimeTypes:
     - x-scheme-handler/x-github-client
     - x-scheme-handler/x-github-desktop-auth
-    //workaround for handling OAuth flow until we figure out what we're doing 
-    //With the development OAuth details
-    //see https://github.com/shiftkey/desktop/issues/72 for more details
+    # workaround for handling OAuth flow until we figure out what we're doing 
+    # With the development OAuth details
+    # see https://github.com/shiftkey/desktop/issues/72 for more details
     - x-scheme-handler/x-github-desktop-dev-auth
   target:
     - AppImage

--- a/script/electron-builder-linux.yml
+++ b/script/electron-builder-linux.yml
@@ -6,6 +6,10 @@ linux:
   mimeTypes:
     - x-scheme-handler/x-github-client
     - x-scheme-handler/x-github-desktop-auth
+    //workaround for handling OAuth flow until we figure out what we're doing 
+   // with the development OAuth details 
+   // 
+   // see https://github.com/shiftkey/desktop/issues/72 for more details
     - x-scheme-handler/x-github-desktop-dev-auth
   target:
     - AppImage

--- a/script/electron-builder-linux.yml
+++ b/script/electron-builder-linux.yml
@@ -6,6 +6,7 @@ linux:
   mimeTypes:
     - x-scheme-handler/x-github-client
     - x-scheme-handler/x-github-desktop-auth
+    - x-scheme-handler/x-github-desktop-dev-auth
   target:
     - AppImage
   maintainer: 'GitHub, Inc <opensource+desktop@github.com>'

--- a/script/electron-builder-linux.yml
+++ b/script/electron-builder-linux.yml
@@ -7,9 +7,8 @@ linux:
     - x-scheme-handler/x-github-client
     - x-scheme-handler/x-github-desktop-auth
     //workaround for handling OAuth flow until we figure out what we're doing 
-   // with the development OAuth details 
-   // 
-   // see https://github.com/shiftkey/desktop/issues/72 for more details
+    //With the development OAuth details
+    //see https://github.com/shiftkey/desktop/issues/72 for more details
     - x-scheme-handler/x-github-desktop-dev-auth
   target:
     - AppImage


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->
 it should  close    #416 in terms of appimages 

## Description

-adds missing MIME type to the electron builder ,  `x-scheme-handler/x-github-desktop-dev-auth` which  is mentioned in the red-hat builder and debian builder  but not the electron builder 

https://github.com/shiftkey/desktop/blob/e2e04839e4151b10a62cfa1beee573deedd12be0/script/package-debian.ts#L67-L74
https://github.com/shiftkey/desktop/blob/e2e04839e4151b10a62cfa1beee573deedd12be0/script/package-redhat.ts#L65-L71
what  made me look at this was https://github.com/shiftkey/desktop/issues/416#issuecomment-782940012
### Screenshots
N/A

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:no-notes 