### PR TITLE
Readme : mention Github Auth  for appimages

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ the installers for Debian and RPM-based distributions. These are not free servic
 so if you can afford to help with these costs please [**Sponsor**](https://github.com/sponsors/shiftkey)
 the project using the link in the header.
 
+## Using Github Auth with the Appimages 
+
+Github desktop uses github Auth  for logins due to this the process can be a bit different for Appimages 
+when you click authorize  the  application the  said browser will auto look for Github Desktop , due to how Appimages work  the said browser may  not correctly find  it  , you may have to manually  tell the browser to open with the specific appimage
+
 ### Debian/Ubuntu distributions
 
 To setup the package repository, run these commands:

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ the project using the link in the header.
 
 ## Using Github Auth with the Appimages 
 
-Github desktop uses github Auth  for logins due to this the process can be a bit different for Appimages 
-when you click authorize  the  application the  said browser will auto look for Github Desktop , due to how Appimages work  the said browser may  not correctly find  it  , you may have to manually  tell the browser to open with the specific appimage
+Github desktop uses Github Auth  for logins due to this the process can be a bit different for Appimages 
+when you click authorize  the  application the  said browser will auto look for Github Desktop , due to how Appimages work  the said browser may  not correctly find it,you may have to manually tell the browser to open with the specific Appimage
 
 ### Debian/Ubuntu distributions
 


### PR DESCRIPTION
## Description

Adds mention to the readme , when authenticating login  the browser used  may not   automatically find   the appimage to send the auth message to  and tells the user that may have to manually select the appimage in open with... in the  browser 
## Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

N/A

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: No-notes 
