### PR TITLE
adds integrations for neovim and the flatpak version of VSCodium 

### DIFF
--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -21,6 +21,10 @@ const editors: ILinuxExternalEditor[] = [
     paths: ['/snap/bin/atom', '/usr/bin/atom'],
   },
   {
+    name: 'Neovim',
+    paths: ['/usr/bin/nvim'],
+  },
+  {
     name: 'Visual Studio Code',
     paths: ['/usr/share/code/bin/code', '/snap/bin/code', '/usr/bin/code'],
   },
@@ -30,7 +34,7 @@ const editors: ILinuxExternalEditor[] = [
   },
   {
     name: 'VSCodium',
-    paths: ['/usr/bin/codium'],
+    paths: ['/usr/bin/codium','/var/lib/flatpak/app/com.vscodium.codium'],
   },
   {
     name: 'Sublime Text',


### PR DESCRIPTION

hopefull closes  #495

## Description

adds intergrations neovim (/usr/bin/nvim)  and the flatpak version of VSCodium (/var/lib/flatpak/app/com.vscodium.codium')

needs to tested by the user having the issue tho 
### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

N/A 

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->
N/A

Notes:
