### PR TITLE
Fix editor and terminal app detection in flatpak containers

### DIFF
--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -34,7 +34,7 @@ const editors: ILinuxExternalEditor[] = [
   },
   {
     name: 'VSCodium',
-    paths: ['/usr/bin/codium', '/usr/bin/vscodium', '/var/lib/flatpak/app/com.vscodium.codium', '/var/run/host/usr/bin/codium', '/var/run/host/usr/bin/vscodium'],
+    paths: ['/usr/bin/codium', '/var/lib/flatpak/app/com.vscodium.codium', '/var/run/host/usr/bin/codium'],
   },
   {
     name: 'Sublime Text',

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -18,31 +18,31 @@ interface ILinuxExternalEditor {
 const editors: ILinuxExternalEditor[] = [
   {
     name: 'Atom',
-    paths: ['/snap/bin/atom', '/usr/bin/atom'],
+    paths: ['/snap/bin/atom', '/usr/bin/atom', '/var/run/host/usr/bin/atom'],
   },
   {
     name: 'Neovim',
-    paths: ['/usr/bin/nvim'],
+    paths: ['/usr/bin/nvim', '/var/run/host/usr/bin/nvim'],
   },
   {
     name: 'Visual Studio Code',
-    paths: ['/usr/share/code/bin/code', '/snap/bin/code', '/usr/bin/code'],
+    paths: ['/usr/share/code/bin/code', '/snap/bin/code', '/usr/bin/code', '/var/run/host/usr/bin/code'],
   },
   {
     name: 'Visual Studio Code (Insiders)',
-    paths: ['/snap/bin/code-insiders', '/usr/bin/code-insiders'],
+    paths: ['/snap/bin/code-insiders', '/usr/bin/code-insiders', '/var/run/host/usr/bin/code-insiders'],
   },
   {
     name: 'VSCodium',
-    paths: ['/usr/bin/codium', '/var/lib/flatpak/app/com.vscodium.codium'],
+    paths: ['/usr/bin/codium', '/var/lib/flatpak/app/com.vscodium.codium', '/var/run/host/usr/bin/codium'],
   },
   {
     name: 'Sublime Text',
-    paths: ['/usr/bin/subl'],
+    paths: ['/usr/bin/subl', '/var/run/host/usr/bin/subl'],
   },
   {
     name: 'Typora',
-    paths: ['/usr/bin/typora'],
+    paths: ['/usr/bin/typora', '/var/run/host/usr/bin/typora'],
   },
   {
     name: 'SlickEdit',
@@ -57,7 +57,7 @@ const editors: ILinuxExternalEditor[] = [
     // Code editor for elementary OS
     // https://github.com/elementary/code
     name: 'Code',
-    paths: ['/usr/bin/io.elementary.code'],
+    paths: ['/usr/bin/io.elementary.code', '/var/run/host/usr/bin/io.elementary.code'],
   },
 ]
 

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -34,7 +34,7 @@ const editors: ILinuxExternalEditor[] = [
   },
   {
     name: 'VSCodium',
-    paths: ['/usr/bin/codium', '/var/lib/flatpak/app/com.vscodium.codium', '/var/run/host/usr/bin/codium'],
+    paths: ['/usr/bin/codium', '/var/lib/flatpak/app/com.vscodium.codium', '/var/run/host/usr/share/vscodium-bin/bin/codium'],
   },
   {
     name: 'Sublime Text',

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -34,7 +34,7 @@ const editors: ILinuxExternalEditor[] = [
   },
   {
     name: 'VSCodium',
-    paths: ['/usr/bin/codium', '/var/lib/flatpak/app/com.vscodium.codium', '/var/run/host/usr/bin/codium'],
+    paths: ['/usr/bin/codium', '/usr/bin/vscodium', '/var/lib/flatpak/app/com.vscodium.codium', '/var/run/host/usr/bin/codium', '/var/run/host/usr/bin/vscodium'],
   },
   {
     name: 'Sublime Text',

--- a/app/src/lib/shells/linux.ts
+++ b/app/src/lib/shells/linux.ts
@@ -27,7 +27,12 @@ export function parse(label: string): Shell {
 }
 
 async function getPathIfAvailable(path: string): Promise<string | null> {
-  return (await pathExists(path)) ? path : null
+  if (process.env.FLATPAK_HOST !== 'undefined') {
+    path = "/var/run/host".toString().concat(path)
+    return (await pathExists(path)) ? path : null
+  } else {
+    return (await pathExists(path)) ? path : null
+  }
 }
 
 function getShellPath(shell: Shell): Promise<string | null> {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #553 
## Description
This fixed editors and terminal apps such as konsole not being detected by github desktop in flatpaks by adding the path of where the files will be in a flatpak container