### PR TITLE
introduce abstractions to make Flatpak integration easier

### DIFF
--- a/app/src/lib/editors/found-editor.ts
+++ b/app/src/lib/editors/found-editor.ts
@@ -1,5 +1,11 @@
 export interface IFoundEditor<T> {
   readonly editor: T
   readonly path: string
+  /**
+   * Indicate to Desktop to launch the editor with the `shell: true` option included.
+   *
+   * This is available to all platforms, but is only currently used by some Windows
+   * editors as their launch programs end in `.cmd`
+   */
   readonly usesShell?: boolean
 }

--- a/app/src/lib/editors/launch.ts
+++ b/app/src/lib/editors/launch.ts
@@ -1,6 +1,24 @@
 import { spawn, SpawnOptions } from 'child_process'
-import { pathExists } from 'fs-extra'
+import { pathExists as pathExistsDefault } from 'fs-extra'
+import { pathExists as pathExistsLinux, spawnEditor } from '../helpers/linux'
 import { ExternalEditorError, FoundEditor } from './shared'
+
+/**
+ * Use a platform-specific pathExists based on the platform, to simplify changes
+ * to the application logic
+ *
+ * @param path the location of some program on disk
+ *
+ * @returns `true` if the path exists on disk, or `false` otherwise
+ *
+ */
+function pathExists(path: string) {
+  if (__LINUX__) {
+    return pathExistsLinux(path)
+  } else {
+    return pathExistsDefault(path)
+  }
+}
 
 /**
  * Open a given file or folder in the desired external editor.
@@ -35,6 +53,8 @@ export async function launchExternalEditor(
     // In macOS we can use `open`, which will open the right executable file
     // for us, we only need the path to the editor .app folder.
     spawn('open', ['-a', editorPath, fullPath], opts)
+  } else if (__LINUX__) {
+    spawnEditor(editorPath, fullPath, opts)
   } else {
     spawn(editorPath, [fullPath], opts)
   }

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -34,7 +34,11 @@ const editors: ILinuxExternalEditor[] = [
   },
   {
     name: 'VSCodium',
-    paths: ['/usr/bin/codium', '/var/lib/flatpak/app/com.vscodium.codium'],
+    paths: [
+      '/usr/bin/codium',
+      '/var/lib/flatpak/app/com.vscodium.codium',
+      '/usr/share/vscodium-bin/bin/codium',
+    ],
   },
   {
     name: 'Sublime Text',

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -1,4 +1,4 @@
-import { pathExists } from 'fs-extra'
+import { pathExists } from '../helpers/linux'
 
 import { IFoundEditor } from './found-editor'
 

--- a/app/src/lib/helpers/linux.ts
+++ b/app/src/lib/helpers/linux.ts
@@ -1,3 +1,57 @@
+import { join } from 'path'
+import { pathExists as pathExistsInternal } from 'fs-extra'
+import { spawn, SpawnOptionsWithoutStdio } from 'child_process'
+
 export function isFlatpakBuild() {
   return __LINUX__ && process.env.FLATPAK_HOST === '1'
+}
+
+/**
+ * Convert an executable path to be relative to the flatpak host
+ *
+ * @param path a path to an executable relative to the root of the filesystem
+ *
+ */
+function convertToFlatpakPath(path: string) {
+  return join('/var/run/host', path)
+}
+
+/**
+ * Checks the file path on disk exists before attempting to launch a specific shell
+ *
+ * @param path
+ *
+ * @returns `true` if the path can be resolved, or `false` otherwise
+ */
+export async function pathExists(path: string): Promise<boolean> {
+  if (isFlatpakBuild()) {
+    path = convertToFlatpakPath(path)
+  }
+
+  try {
+    return await pathExistsInternal(path)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Spawn a particular shell in a way that works for Flatpak-based usage
+ *
+ * @param path path to shell, relative to the root of the filesystem
+ * @param args arguments to provide to the shell
+ * @param options additional options to provide to spawn
+ *
+ * @returns a child process to observe and monitor
+ */
+export function spawnShell(
+  path: string,
+  args: string[],
+  options?: SpawnOptionsWithoutStdio
+) {
+  if (isFlatpakBuild()) {
+    return spawn('flatpak-spawn', ['--host', path, ...args], options)
+  }
+
+  return spawn(path, args, options)
 }

--- a/app/src/lib/helpers/linux.ts
+++ b/app/src/lib/helpers/linux.ts
@@ -84,7 +84,7 @@ export function spawnEditor(
   if (isFlatpakBuild()) {
     return spawn(
       'flatpak-spawn',
-      ['--host', `"${path}"`, `"${workingDirectory}"`],
+      ['--host', path, `"${workingDirectory}"`],
       options
     )
   } else {

--- a/app/src/lib/helpers/linux.ts
+++ b/app/src/lib/helpers/linux.ts
@@ -18,6 +18,10 @@ export function isFlatpakBuild() {
  *
  */
 export function convertToFlatpakPath(path: string) {
+  if (!__LINUX__) {
+    return path
+  }
+
   if (path.startsWith('/opt/')) {
     return path
   }

--- a/app/src/lib/helpers/linux.ts
+++ b/app/src/lib/helpers/linux.ts
@@ -1,0 +1,3 @@
+export function isFlatpakBuild() {
+  return __LINUX__ && process.env.FLATPAK_HOST === '1'
+}

--- a/app/src/lib/helpers/linux.ts
+++ b/app/src/lib/helpers/linux.ts
@@ -17,7 +17,11 @@ export function isFlatpakBuild() {
  * @param path a path to an executable relative to the root of the filesystem
  *
  */
-function convertToFlatpakPath(path: string) {
+export function convertToFlatpakPath(path: string) {
+  if (path.startsWith('/opt/')) {
+    return path
+  }
+
   return join('/var/run/host', path)
 }
 

--- a/app/src/lib/shells/linux.ts
+++ b/app/src/lib/shells/linux.ts
@@ -1,8 +1,8 @@
-import { spawn, ChildProcess } from 'child_process'
-import { pathExists } from 'fs-extra'
+import { ChildProcess } from 'child_process'
 import { assertNever } from '../fatal-error'
 import { IFoundShell } from './found-shell'
 import { parseEnumValue } from '../enum'
+import { pathExists as pathExistsLinux, spawnShell } from '../helpers/linux'
 
 export enum Shell {
   Gnome = 'GNOME Terminal',
@@ -27,7 +27,7 @@ export function parse(label: string): Shell {
 }
 
 async function getPathIfAvailable(path: string): Promise<string | null> {
-  return (await pathExists(path)) ? path : null
+  return (await pathExistsLinux(path)) ? path : null
 }
 
 function getShellPath(shell: Shell): Promise<string | null> {
@@ -164,21 +164,25 @@ export function launch(
     case Shell.Terminator:
     case Shell.XFCE:
     case Shell.Alacritty:
-      return spawn(foundShell.path, ['--working-directory', path])
+      return spawnShell(foundShell.path, ['--working-directory', path])
     case Shell.Urxvt:
-      return spawn(foundShell.path, ['-cd', path])
+      return spawnShell(foundShell.path, ['-cd', path])
     case Shell.Konsole:
-      return spawn(foundShell.path, ['--workdir', path])
+      return spawnShell(foundShell.path, ['--workdir', path])
     case Shell.Xterm:
-      return spawn(foundShell.path, ['-e', '/bin/bash'], { cwd: path })
+      return spawnShell(foundShell.path, ['-e', '/bin/bash'], { cwd: path })
     case Shell.Terminology:
-      return spawn(foundShell.path, ['-d', path])
+      return spawnShell(foundShell.path, ['-d', path])
     case Shell.Deepin:
-      return spawn(foundShell.path, ['-w', path])
+      return spawnShell(foundShell.path, ['-w', path])
     case Shell.Elementary:
-      return spawn(foundShell.path, ['-w', path])
+      return spawnShell(foundShell.path, ['-w', path])
     case Shell.Kitty:
-      return spawn(foundShell.path, ['--single-instance', '--directory', path])
+      return spawnShell(foundShell.path, [
+        '--single-instance',
+        '--directory',
+        path,
+      ])
     default:
       return assertNever(shell, `Unknown shell: ${shell}`)
   }

--- a/app/src/lib/shells/shared.ts
+++ b/app/src/lib/shells/shared.ts
@@ -1,9 +1,10 @@
 import { ChildProcess } from 'child_process'
-import { pathExists } from 'fs-extra'
+import { pathExists as pathExistsDefault } from 'fs-extra'
 
 import * as Darwin from './darwin'
 import * as Win32 from './win32'
 import * as Linux from './linux'
+import { pathExists as pathExistsLinux } from '../helpers/linux'
 import { IFoundShell } from './found-shell'
 import { ShellError } from './error'
 
@@ -69,6 +70,23 @@ export async function findShellOrDefault(shell: Shell): Promise<FoundShell> {
     return found
   } else {
     return available.find(s => s.shell === Default)!
+  }
+}
+
+/**
+ * Use a platform-specific pathExists based on the platform, to simplify changes
+ * to the application logic
+ *
+ * @param path the location of some program on disk
+ *
+ * @returns `true` if the path exists on disk, or `false` otherwise
+ *
+ */
+function pathExists(path: string) {
+  if (__LINUX__) {
+    return pathExistsLinux(path)
+  } else {
+    return pathExistsDefault(path)
   }
 }
 

--- a/app/test/unit/helpers/linux-test.ts
+++ b/app/test/unit/helpers/linux-test.ts
@@ -1,7 +1,7 @@
 import { convertToFlatpakPath } from '../../../src/lib/helpers/linux'
 
-if (__LINUX__) {
-  describe('convertToFlatpakPath()', () => {
+describe('convertToFlatpakPath()', () => {
+  if (__LINUX__) {
     it('converts /usr paths', () => {
       const path = '/usr/bin/subl'
       const expectedPath = '/var/run/host/usr/bin/subl'
@@ -12,5 +12,19 @@ if (__LINUX__) {
       const path = '/opt/slickedit-pro2018/bin/vs'
       expect(convertToFlatpakPath(path)).toEqual(path)
     })
-  })
-}
+  }
+
+  if (__WIN32__) {
+    it('returns same path', () => {
+      const path = 'C:\\Windows\\System32\\Notepad.exe'
+      expect(convertToFlatpakPath(path)).toEqual(path)
+    })
+  }
+
+  if (__DARWIN__) {
+    it('returns same path', () => {
+      const path = '/usr/local/bin/code'
+      expect(convertToFlatpakPath(path)).toEqual(path)
+    })
+  }
+})

--- a/app/test/unit/helpers/linux-test.ts
+++ b/app/test/unit/helpers/linux-test.ts
@@ -1,14 +1,16 @@
 import { convertToFlatpakPath } from '../../../src/lib/helpers/linux'
 
-describe('convertToFlatpakPath()', () => {
-  it('converts /usr paths', () => {
-    const path = '/usr/bin/subl'
-    const expectedPath = '/var/run/host/usr/bin/subl'
-    expect(convertToFlatpakPath(path)).toEqual(expectedPath)
-  })
+if (__LINUX__) {
+  describe('convertToFlatpakPath()', () => {
+    it('converts /usr paths', () => {
+      const path = '/usr/bin/subl'
+      const expectedPath = '/var/run/host/usr/bin/subl'
+      expect(convertToFlatpakPath(path)).toEqual(expectedPath)
+    })
 
-  it('preserves /opt paths', () => {
-    const path = '/opt/slickedit-pro2018/bin/vs'
-    expect(convertToFlatpakPath(path)).toEqual(path)
+    it('preserves /opt paths', () => {
+      const path = '/opt/slickedit-pro2018/bin/vs'
+      expect(convertToFlatpakPath(path)).toEqual(path)
+    })
   })
-})
+}

--- a/app/test/unit/helpers/linux-test.ts
+++ b/app/test/unit/helpers/linux-test.ts
@@ -1,0 +1,14 @@
+import { convertToFlatpakPath } from '../../../src/lib/helpers/linux'
+
+describe('convertToFlatpakPath()', () => {
+  it('converts /usr paths', () => {
+    const path = '/usr/bin/subl'
+    const expectedPath = '/var/run/host/usr/bin/subl'
+    expect(convertToFlatpakPath(path)).toEqual(expectedPath)
+  })
+
+  it('preserves /opt paths', () => {
+    const path = '/opt/slickedit-pro2018/bin/vs'
+    expect(convertToFlatpakPath(path)).toEqual(path)
+  })
+})


### PR DESCRIPTION
Related to #554 but enables us to better combine regular usage as well as integration with the Flatpak host

I've moved the `pathExists` and `spawn` usage into a standalone module, so we can keep this platform-specific code isolated from the rest of this app. Not sure how feasible this is, but I hope it makes things easier to reason about if they're funnelling through the same functions (which we can adapt based on the requirements).

cc @advaithm for thoughts

I'll add some notes in the PR to help guide the discussion about these changes

### TODO

 - [x] get feedback about changes
 - [x] add new vscodium path
 - [x] ensure CI passes
 - [x] test regular usage of app in development mode to ensure no regressions


