### PR TITLE
fixed code editor detection and launching

### DIFF
--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -1,4 +1,4 @@
-import { pathExists } from 'fs-extra'
+import { pathExists } from '../helpers/linux'
 
 import { IFoundEditor } from './found-editor'
 

--- a/app/src/lib/helpers/linux.ts
+++ b/app/src/lib/helpers/linux.ts
@@ -84,7 +84,7 @@ export function spawnEditor(
   if (isFlatpakBuild()) {
     return spawn(
       'flatpak-spawn',
-      ['--host', `"${path}"`, `"${workingDirectory}"`],
+      ['--host', path, `"${workingDirectory}"`],
       options
     )
   } else {


### PR DESCRIPTION
Fixed it although intermittently the path opened in the code editor has " appended to it, for example if I opened the path `~/desktop` it would sometimes open as `~/desktop"` I'm unable to reliable reproduce this is reliably enough to debug this issue.  CLI(like neovim) editors do not work. Unsure of why