### PR TITLE
escape paths with regex over quotes in flatpaks

### DIFF
--- a/app/src/lib/helpers/linux.ts
+++ b/app/src/lib/helpers/linux.ts
@@ -28,7 +28,9 @@ export function convertToFlatpakPath(path: string) {
 
   return join('/var/run/host', path)
 }
-
+export function formatWorkingDirectoryForFlatpak(path: string): string {
+  return path.replace(/(\s)/, "\ ")
+}
 /**
  * Checks the file path on disk exists before attempting to launch a specific shell
  *
@@ -82,7 +84,7 @@ export function spawnEditor(
   options: SpawnOptions
 ): ChildProcess {
   if (isFlatpakBuild()) {
-    let EscapedworkingDirectory = workingDirectory.replace(/(\s)/, "\ ")
+    let EscapedworkingDirectory = formatWorkingDirectoryForFlatpak(workingDirectory)
     return spawn(
       'flatpak-spawn',
       ['--host', path, EscapedworkingDirectory],

--- a/app/src/lib/helpers/linux.ts
+++ b/app/src/lib/helpers/linux.ts
@@ -82,9 +82,10 @@ export function spawnEditor(
   options: SpawnOptions
 ): ChildProcess {
   if (isFlatpakBuild()) {
+    let EscapedworkingDirectory = workingDirectory.replace(/(\s)/, "\ ")
     return spawn(
       'flatpak-spawn',
-      ['--host', path, `"${workingDirectory}"`],
+      ['--host', path, EscapedworkingDirectory],
       options
     )
   } else {

--- a/app/src/lib/helpers/linux.ts
+++ b/app/src/lib/helpers/linux.ts
@@ -82,9 +82,10 @@ export function spawnEditor(
   options: SpawnOptions
 ): ChildProcess {
   if (isFlatpakBuild()) {
+    let EscapedworkingDirectory = workingDirectory.replace(/(\s)/, "\\ ")
     return spawn(
       'flatpak-spawn',
-      ['--host', path, `"${workingDirectory}"`],
+      ['--host', path, EscapedworkingDirectory],
       options
     )
   } else {

--- a/app/src/lib/helpers/linux.ts
+++ b/app/src/lib/helpers/linux.ts
@@ -82,10 +82,9 @@ export function spawnEditor(
   options: SpawnOptions
 ): ChildProcess {
   if (isFlatpakBuild()) {
-    let EscapedworkingDirectory = workingDirectory.replace(/(\s)/, "\\ ")
     return spawn(
       'flatpak-spawn',
-      ['--host', path, EscapedworkingDirectory],
+      ['--host', path, `"${workingDirectory}"`],
       options
     )
   } else {

--- a/app/test/unit/helpers/linux-test.ts
+++ b/app/test/unit/helpers/linux-test.ts
@@ -1,4 +1,4 @@
-import { convertToFlatpakPath } from '../../../src/lib/helpers/linux'
+import { convertToFlatpakPath, formatWorkingDirectoryForFlatpak } from '../../../src/lib/helpers/linux'
 
 describe('convertToFlatpakPath()', () => {
   if (__LINUX__) {
@@ -25,6 +25,20 @@ describe('convertToFlatpakPath()', () => {
     it('returns same path', () => {
       const path = '/usr/local/bin/code'
       expect(convertToFlatpakPath(path)).toEqual(path)
+    })
+  }
+})
+
+describe('formatWorkingDirectoryForFlatpak()', () => {
+  if (__LINUX__) {
+    it('escapes string', () => {
+      const path = "/home/test/path with space"
+      const expectedPath = "/home/test/path\ with\ space"
+      expect(formatWorkingDirectoryForFlatpak(path)).toEqual(expectedPath)
+    })
+    it('returns same path', () => {
+      const path = "/home/test/path_wthout_spaces"
+      expect(formatWorkingDirectoryForFlatpak(path)).toEqual(path)
     })
   }
 })


### PR DESCRIPTION
For some reason this stops an intermittent issue where the path supplied to the editor binary would be append with a ". 
