### PR TITLE
restore windowOptions.icon assignment for AppWindow

### DIFF
--- a/app/src/main-process/app-window.ts
+++ b/app/src/main-process/app-window.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow, ipcMain, Menu, app, dialog } from 'electron'
 import { Emitter, Disposable } from 'event-kit'
+import { join } from 'path'
 import { encodePathAsUrl } from '../lib/path'
 import { registerWindowStateChangedEvents } from '../lib/window-state'
 import { MenuEvent } from './menu'
@@ -56,6 +57,8 @@ export class AppWindow {
     } else if (__WIN32__) {
       windowOptions.frame = false
     } else if (__LINUX__) {
+      windowOptions.icon = join(__dirname, 'static', 'logos', '512x512.png')
+
       // relax restriction here for users trying to run app at a small
       // resolution and any other side-effects of dropping this restriction are
       // currently unsupported


### PR DESCRIPTION
Backs out the removal of `windowOptions.icon` in #530 as this seems to be used in scenarios that I didn't cover when testing.

This uses one of the newer icons, and it's the same resolution as the old icon so hopefully that's compatible with this scenario.