### PR TITLE
include owner in local path when cloning a repository #5449

### DIFF
--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -562,15 +562,15 @@ export class CloneRepository extends React.Component<
     const lastParsedIdentifier = tabState.lastParsedIdentifier
 
     let newPath: string
-
+     //parsed.owner adds the repo owner to the path - helps while cloning 2 repos with same name but from different owners ( Primarily while Forking)
     if (lastParsedIdentifier) {
       if (parsed) {
-        newPath = Path.join(Path.dirname(tabState.path), parsed.name)
+        newPath = Path.join(Path.dirname(tabState.path),parsed.owner,parsed.name)
       } else {
         newPath = Path.dirname(tabState.path)
       }
     } else if (parsed) {
-      newPath = Path.join(tabState.path, parsed.name)
+      newPath = Path.join(tabState.path,parsed.owner,parsed.name)
     } else {
       newPath = tabState.path
     }


### PR DESCRIPTION
parsed.owner adds the repo owner to the path - helps while cloning 2 repos with same name but from different owners ( Primarily while Forking)

<!--
include owner in local path when cloning a repository #5449
-->

Addresses Issues #[5449, 6430,7685, 12583] - shiftkey #[570]
Closes#[5449]

## Description

<!--
Before Commit:
![Selection_005](https://user-images.githubusercontent.com/4012718/127595128-3adaec3c-86e9-44e3-95b6-8199f5a7d31e.png)

After commit:
![Selection_006](https://user-images.githubusercontent.com/4012718/127595136-967ddc4d-e0cb-4342-9323-6c5ad8659c23.png)


-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
