### PR TITLE
Added Kate and gEdit to editors

### DIFF
--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -63,6 +63,14 @@ const editors: ILinuxExternalEditor[] = [
     name: 'Code',
     paths: ['/usr/bin/io.elementary.code'],
   },
+  {
+    name: 'Kate',
+    paths: ['/usr/bin/kate'],
+  },
+  {
+    name: 'GNOME Text Editor',
+    paths: ['/usr/bin/gedit'],
+  },
 ]
 
 async function getAvailablePath(paths: string[]): Promise<string | null> {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #575

## Description

Adds Kate and gEdit to supported editors.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
