### PR TITLE
git submodules should be updated if not offline

### DIFF
--- a/script/post-install.ts
+++ b/script/post-install.ts
@@ -53,7 +53,7 @@ findYarnVersion(path => {
     process.exit(result.status || 1)
   }
 
-  if (isOffline()) {
+  if (!isOffline()) {
     result = spawnSync(
       'git',
       ['submodule', 'update', '--recursive', '--init'],


### PR DESCRIPTION
This PR fixes an issue spotted downstream in the Arch Linux packaging. From a clean build and package they were not seeing the submodules exist on disk, which meant the app didn't build. https://github.com/alerque/aur/pull/22 is the workaround for that case.

I was able to reproduce this on macOS with a fresh clone:

```
> git clone https://github.com/shiftkey/desktop desktop-fresh-clone
Cloning into 'desktop-fresh-clone'...
remote: Enumerating objects: 208353, done.
remote: Counting objects: 100% (745/745), done.
remote: Compressing objects: 100% (304/304), done.
remote: Total 208353 (delta 501), reused 589 (delta 438), pack-reused 207608
Receiving objects: 100% (208353/208353), 71.77 MiB | 18.22 MiB/s, done.
Resolving deltas: 100% (166509/166509), done.

> cd desktop-fresh-clone
> yarn
yarn install v1.21.1
[1/5] 🔍  Validating package.json...
[2/5] 🔍  Resolving packages...
[3/5] 🚚  Fetching packages...
[4/5] 🔗  Linking dependencies...
[5/5] 🔨  Building fresh packages...
warning Your current version of Yarn is out of date. The latest version is "1.22.5", while you're on "1.21.1".
$ ts-node -P script/tsconfig.json script/post-install.ts
yarn install v1.21.1
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 🔨  Rebuilding all packages...
success Saved lockfile.
✨  Done in 23.54s.
yarn run v1.21.1
$ tsc -P script/tsconfig.json
✨  Done in 20.40s.
✨  Done in 104.66s.

> yarn build:dev
yarn run v1.21.1
$ yarn compile:dev && cross-env NODE_ENV=development ts-node -P script/tsconfig.json script/build.ts
$ cross-env NODE_ENV=development TS_NODE_PROJECT=script/tsconfig.json parallel-webpack --config app/webpack.development.ts
[WEBPACK] Building 5 targets
[WEBPACK] Started building main.js
[WEBPACK] Started building renderer.js
[WEBPACK] Started building crash.js
[WEBPACK] Started building cli.js
[WEBPACK] Started building highlighter.js
...
[WEBPACK] Finished build after 62.458 seconds
Building for development…
Removing old distribution…
Copying dependencies…
  Installing dependencies via yarn…
warning devtron > highlight.js@9.18.5: Support has ended for 9.x series. Upgrade to @latest
  Copying desktop-trampoline…
  Copying ssh-wrapper
  Copying git environment…
  Copying app-path binary…
Packaging emoji…
Error: ENOENT: no such file or directory, stat '/Users/shiftkey/src/test/desktop-fresh-clone/gemoji/images/emoji'
    at Object.statSync (fs.js:1086:3)
    at Object.statSync (/Users/shiftkey/src/test/desktop-fresh-clone/node_modules/graceful-fs/polyfills.js:307:34)
    at statSync (/Users/shiftkey/src/test/desktop-fresh-clone/node_modules/fs-extra/lib/util/stat.js:10:52)
    at getStatsSync (/Users/shiftkey/src/test/desktop-fresh-clone/node_modules/fs-extra/lib/util/stat.js:24:19)
    at Object.checkPathsSync (/Users/shiftkey/src/test/desktop-fresh-clone/node_modules/fs-extra/lib/util/stat.js:49:33)
    at Object.copySync (/Users/shiftkey/src/test/desktop-fresh-clone/node_modules/fs-extra/lib/copy-sync/copy-sync.js:24:38)
    at removeAndCopy (/Users/shiftkey/src/test/desktop-fresh-clone/script/build.ts:233:6)
    at copyEmoji (/Users/shiftkey/src/test/desktop-fresh-clone/script/build.ts:239:3)
    at Object.<anonymous> (/Users/shiftkey/src/test/desktop-fresh-clone/script/build.ts:66:1)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Module.m._compile (/Users/shiftkey/src/test/desktop-fresh-clone/node_modules/ts-node/src/index.ts:439:23)
    at Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Object.require.extensions.<computed> [as .ts] (/Users/shiftkey/src/test/desktop-fresh-clone/node_modules/ts-node/src/index.ts:442:12)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:72:12)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

I think we've just gotten this check wrong as part of the Flatpak work, and we should be running this when the environment variable is **not** found.

@advaithm when you have time, please confirm I've got this right, and that it's not going to affect the Flatpak side of things...