### PR TITLE
Flatpak: locate and launch flatpaked code editors

### DIFF
--- a/app/src/lib/helpers/linux.ts
+++ b/app/src/lib/helpers/linux.ts
@@ -22,7 +22,7 @@ export function convertToFlatpakPath(path: string) {
     return path
   }
 
-  if (path.startsWith('/opt/') || path.startsWith("/var/lib/flatpak")) {
+  if (path.startsWith('/opt/') || path.startsWith('/var/lib/flatpak')) {
     return path
   }
 
@@ -33,8 +33,8 @@ export function formatWorkingDirectoryForFlatpak(path: string): string {
 }
 
 export function formatPathForFlatpak(path: string): string {
-  if (path.startsWith("/var/lib/flatpak/app")) {
-    return path.replace("/var/lib/flatpak/app/", "")
+  if (path.startsWith('/var/lib/flatpak/app')) {
+    return path.replace('/var/lib/flatpak/app/', '')
   }
   return path
 }

--- a/app/src/lib/helpers/linux.ts
+++ b/app/src/lib/helpers/linux.ts
@@ -22,7 +22,7 @@ export function convertToFlatpakPath(path: string) {
     return path
   }
 
-  if (path.startsWith('/opt/')) {
+  if (path.startsWith('/opt/') || path.startsWith("/var/lib/flatpak")) {
     return path
   }
 
@@ -30,6 +30,13 @@ export function convertToFlatpakPath(path: string) {
 }
 export function formatWorkingDirectoryForFlatpak(path: string): string {
   return path.replace(/(\s)/, ' ')
+}
+
+export function formatPathForFlatpak(path: string): string {
+  if (path.startsWith("/var/lib/flatpak/app")) {
+    return path.replace("/var/lib/flatpak/app/", "")
+  }
+  return path
 }
 /**
  * Checks the file path on disk exists before attempting to launch a specific shell
@@ -84,12 +91,13 @@ export function spawnEditor(
   options: SpawnOptions
 ): ChildProcess {
   if (isFlatpakBuild()) {
+    const actualpath = formatPathForFlatpak(path)
     const EscapedworkingDirectory = formatWorkingDirectoryForFlatpak(
       workingDirectory
     )
     return spawn(
       'flatpak-spawn',
-      ['--host', path, EscapedworkingDirectory],
+      ['--host', actualpath, EscapedworkingDirectory],
       options
     )
   } else {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes https://github.com/flathub/io.github.shiftey.Desktop/issues/9

## Description
this adds the ability to locate flatpaks and run them from flatpak-spawn with their own sandbox.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes
flatpak: allow detection and running of flatpaked code editors