### PR TITLE
Changed apt-get to apt in the debian installation section of the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To setup the package repository, run these commands:
 ```sh
 $ wget -qO - https://packagecloud.io/shiftkey/desktop/gpgkey | sudo tee /etc/apt/trusted.gpg.d/shiftkey-desktop.asc > /dev/null
 $ sudo sh -c 'echo "deb [arch=amd64] https://packagecloud.io/shiftkey/desktop/any/ any main" > /etc/apt/sources.list.d/packagecloud-shiftkey-desktop.list'
-$ sudo apt-get update
+$ sudo apt update
 ```
 
 Then install GitHub Desktop:


### PR DESCRIPTION
Closes #650 

## Description
the apt-get update (deprecated) line on the README file was changed to use apt instead. 

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
