### PR TITLE
enable `supportsSystemThemeChanges()` for all Linux builds

### DIFF
--- a/app/src/ui/lib/application-theme.ts
+++ b/app/src/ui/lib/application-theme.ts
@@ -140,9 +140,11 @@ export function supportsSystemThemeChanges(): boolean {
     // was released October 2nd, 2018 and the feature can just be "attained" by upgrading
     // See https://github.com/desktop/desktop/issues/9015 for more
     return isWindows10And1809Preview17666OrLater()
+  } else {
+    // enabling this for Linux users as an experiment to see if distributions
+    // work with how Chromium detects theme changes
+    return true
   }
-
-  return false
 }
 
 function isDarkModeEnabled(): Promise<boolean> {


### PR DESCRIPTION
Resolves #372 
Resolves #512

## Description

Enabling the `supportsSystemThemeChanges()` change on Linux seems to handle the two cases that were reported earlier:

 - inherit from the system theme if set
 - changing the theme should not require a restart

### Screenshots

#### With "System" chosen and dark theme selected

![](https://user-images.githubusercontent.com/359239/155225068-820b3f55-da65-4306-8594-4696fd8220d7.png)

#### With "System" chosen and light theme selected 

![](https://user-images.githubusercontent.com/359239/155225071-1246f003-bd78-42e3-b650-64f2ccde171a.png)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: enable system theme and synchronising with current OS light/dark theme
