### PR TITLE
Add mirror to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,36 +22,61 @@ It also hosts preview packages for various Linux distributions:
 Check out the [latest releases](https://github.com/shiftkey/desktop/releases) to
 help out with testing on your distribution.
 
-## packagecloud
+## Repositories
 
-We use [PackageCloud](https://packagecloud.io/) for distributing
-the installers for Debian and RPM-based distributions. These are not free services,
-so if you can afford to help with these costs please [**Sponsor**](https://github.com/sponsors/shiftkey)
-the project using the link in the header.
+You can use your operating system's package manager to install `github-desktop` and
+keep it up to date on Debian/RPM based distributions. There are two options for this:
+
+* A [PackageCloud](https://packagecloud.io/) repository with excellent global connectivity
+  but very limited bandwidth. This option will stop working each month when the bandwidth
+  limit is reached.
+* A [mirror](https://mattwthomas.com/mirrors/) in the US which has effectively infinite
+  bandwidth and performs well in most regions (especially the Americas and Europe).
+
+PackageCloud, which both options depend on, is not a free service. So, if you can afford to
+help with these costs please [**Sponsor**](https://github.com/sponsors/shiftkey) the project
+using the link in the header.
 
 ### Debian/Ubuntu distributions
 
-To setup the package repository, run these commands:
+First install our GPG certificate:
 
 ```sh
-$ wget -qO - https://packagecloud.io/shiftkey/desktop/gpgkey | sudo tee /etc/apt/trusted.gpg.d/shiftkey-desktop.asc > /dev/null
+$ wget -qO - https://keys.openpgp.org/vks/v1/by-keyid/7650C43BBA3C3A2C | sudo tee /etc/apt/trusted.gpg.d/shiftkey-desktop.asc > /dev/null
+```
+
+To setup the package repository, run one of these commands:
+
+```sh
+# if you want to use packagecloud.io
 $ sudo sh -c 'echo "deb [arch=amd64] https://packagecloud.io/shiftkey/desktop/any/ any main" > /etc/apt/sources.list.d/packagecloud-shiftkey-desktop.list'
-$ sudo apt update
+
+# if you want to use the US mirror
+$ sudo sh -c 'echo "deb [arch=amd64] https://mirror.mwt.me/ghd/deb/ any main" > /etc/apt/sources.list.d/packagecloud-shiftkey-desktop.list'
 ```
 
 Then install GitHub Desktop:
 
 ```sh
-$ sudo apt install github-desktop
+$ sudo apt update && sudo apt install github-desktop
 ```
 
 ### Red Hat/CentOS/Fedora distributions
 
-To setup the package repository, run these commands:
+First install our GPG certificate:
 
 ```sh
-$ sudo rpm --import https://packagecloud.io/shiftkey/desktop/gpgkey
-$ sudo sh -c 'echo -e "[shiftkey]\nname=GitHub Desktop\nbaseurl=https://packagecloud.io/shiftkey/desktop/el/7/\$basearch\nenabled=1\ngpgcheck=0\nrepo_gpgcheck=1\ngpgkey=https://packagecloud.io/shiftkey/desktop/gpgkey" > /etc/yum.repos.d/shiftkey-desktop.repo'
+$ sudo rpm --import https://keys.openpgp.org/vks/v1/by-keyid/7650C43BBA3C3A2C
+```
+
+To setup the package repository, run one of these commands:
+
+```sh
+# if you want to use packagecloud.io
+$ sudo sh -c 'echo -e "[shiftkey]\nname=GitHub Desktop\nbaseurl=https://packagecloud.io/shiftkey/desktop/el/7/\$basearch\nenabled=1\ngpgcheck=0\nrepo_gpgcheck=1\ngpgkey=https://keys.openpgp.org/vks/v1/by-keyid/7650C43BBA3C3A2C" > /etc/yum.repos.d/shiftkey-desktop.repo'
+
+# if you want to use the US mirror
+$ sudo sh -c 'echo -e "[shiftkey]\nname=GitHub Desktop\nbaseurl=https://mirror.mwt.me/ghd/rpm\nenabled=1\ngpgcheck=0\nrepo_gpgcheck=1\ngpgkey=https://keys.openpgp.org/vks/v1/by-keyid/7650C43BBA3C3A2C" > /etc/yum.repos.d/shiftkey-desktop.repo'
 ```
 
 Then install GitHub Desktop:
@@ -65,9 +90,22 @@ $ sudo dnf install github-desktop
 ```
 
 ### OpenSUSE distribution
+
+
+First install our GPG certificate:
+
 ```sh
-$ sudo rpm --import https://packagecloud.io/shiftkey/desktop/gpgkey
-$ sudo sh -c 'echo -e "[shiftkey]\nname=GitHub Desktop\nbaseurl=https://packagecloud.io/shiftkey/desktop/el/7/\$basearch\nenabled=1\ngpgcheck=0\nrepo_gpgcheck=1\ngpgkey=https://packagecloud.io/shiftkey/desktop/gpgkey" > /etc/zypp/repos.d/shiftkey-desktop.repo'
+$ sudo rpm --import https://keys.openpgp.org/vks/v1/by-keyid/7650C43BBA3C3A2C
+```
+
+To setup the package repository, run one of these commands:
+
+```sh
+# if you want to use packagecloud.io
+$ sudo sh -c 'echo -e "[shiftkey]\nname=GitHub Desktop\nbaseurl=https://packagecloud.io/shiftkey/desktop/el/7/\$basearch\nenabled=1\ngpgcheck=0\nrepo_gpgcheck=1\ngpgkey=https://keys.openpgp.org/vks/v1/by-keyid/7650C43BBA3C3A2C" > /etc/zypp/repos.d/shiftkey-desktop.repo'
+
+# if you want to use the US mirror
+$ sudo sh -c 'echo -e "[shiftkey]\nname=GitHub Desktop\nbaseurl=https://mirror.mwt.me/ghd/rpm\nenabled=1\ngpgcheck=0\nrepo_gpgcheck=1\ngpgkey=https://keys.openpgp.org/vks/v1/by-keyid/7650C43BBA3C3A2C" > /etc/zypp/repos.d/shiftkey-desktop.repo'
 ```
 
 Then install GitHub Desktop:

--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ Arch Linux users can install GitHub Desktop from the
 
 `gnome-keyring` is required and the daemon must be launched either at login or when the X server is started. Normally this is handled by a display manager, but in other cases following the instructions found on the [Arch Wiki](https://wiki.archlinux.org/index.php/GNOME/Keyring#Using_the_keyring_outside_GNOME) will fix the issue of not being able to save login credentials.
 
+GitHub Desktop is also available cross-platform as a [Flatpak](https://github.com/flathub/io.github.shiftey.Desktop) and [AppImage](https://appimage.github.io/GitHubDesktop/).
+
 ## Known issues
 
 If you're having troubles with Desktop, please refer to the [Known issues](docs/known-issues.md#linux)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ using the link in the header.
 First install our GPG certificate:
 
 ```sh
-$ wget -qO - https://keys.openpgp.org/vks/v1/by-keyid/7650C43BBA3C3A2C | sudo tee /etc/apt/trusted.gpg.d/shiftkey-desktop.asc > /dev/null
+$ wget -qO - https://mirror.mwt.me/ghd/gpgkey | sudo tee /etc/apt/trusted.gpg.d/shiftkey-desktop.asc > /dev/null
 ```
 
 To setup the package repository, run one of these commands:
@@ -66,17 +66,17 @@ $ sudo apt update && sudo apt install github-desktop
 First install our GPG certificate:
 
 ```sh
-$ sudo rpm --import https://keys.openpgp.org/vks/v1/by-keyid/7650C43BBA3C3A2C
+$ sudo rpm --import https://mirror.mwt.me/ghd/gpgkey
 ```
 
 To setup the package repository, run one of these commands:
 
 ```sh
 # if you want to use packagecloud.io
-$ sudo sh -c 'echo -e "[shiftkey]\nname=GitHub Desktop\nbaseurl=https://packagecloud.io/shiftkey/desktop/el/7/\$basearch\nenabled=1\ngpgcheck=0\nrepo_gpgcheck=1\ngpgkey=https://keys.openpgp.org/vks/v1/by-keyid/7650C43BBA3C3A2C" > /etc/yum.repos.d/shiftkey-desktop.repo'
+$ sudo sh -c 'echo -e "[shiftkey]\nname=GitHub Desktop\nbaseurl=https://packagecloud.io/shiftkey/desktop/el/7/\$basearch\nenabled=1\ngpgcheck=0\nrepo_gpgcheck=1\ngpgkey=https://mirror.mwt.me/ghd/gpgkey" > /etc/yum.repos.d/shiftkey-desktop.repo'
 
 # if you want to use the US mirror
-$ sudo sh -c 'echo -e "[shiftkey]\nname=GitHub Desktop\nbaseurl=https://mirror.mwt.me/ghd/rpm\nenabled=1\ngpgcheck=0\nrepo_gpgcheck=1\ngpgkey=https://keys.openpgp.org/vks/v1/by-keyid/7650C43BBA3C3A2C" > /etc/yum.repos.d/shiftkey-desktop.repo'
+$ sudo sh -c 'echo -e "[shiftkey]\nname=GitHub Desktop\nbaseurl=https://mirror.mwt.me/ghd/rpm\nenabled=1\ngpgcheck=0\nrepo_gpgcheck=1\ngpgkey=https://mirror.mwt.me/ghd/gpgkey" > /etc/yum.repos.d/shiftkey-desktop.repo'
 ```
 
 Then install GitHub Desktop:
@@ -95,17 +95,17 @@ $ sudo dnf install github-desktop
 First install our GPG certificate:
 
 ```sh
-$ sudo rpm --import https://keys.openpgp.org/vks/v1/by-keyid/7650C43BBA3C3A2C
+$ sudo rpm --import https://mirror.mwt.me/ghd/gpgkey
 ```
 
 To setup the package repository, run one of these commands:
 
 ```sh
 # if you want to use packagecloud.io
-$ sudo sh -c 'echo -e "[shiftkey]\nname=GitHub Desktop\nbaseurl=https://packagecloud.io/shiftkey/desktop/el/7/\$basearch\nenabled=1\ngpgcheck=0\nrepo_gpgcheck=1\ngpgkey=https://keys.openpgp.org/vks/v1/by-keyid/7650C43BBA3C3A2C" > /etc/zypp/repos.d/shiftkey-desktop.repo'
+$ sudo sh -c 'echo -e "[shiftkey]\nname=GitHub Desktop\nbaseurl=https://packagecloud.io/shiftkey/desktop/el/7/\$basearch\nenabled=1\ngpgcheck=0\nrepo_gpgcheck=1\ngpgkey=https://mirror.mwt.me/ghd/gpgkey" > /etc/zypp/repos.d/shiftkey-desktop.repo'
 
 # if you want to use the US mirror
-$ sudo sh -c 'echo -e "[shiftkey]\nname=GitHub Desktop\nbaseurl=https://mirror.mwt.me/ghd/rpm\nenabled=1\ngpgcheck=0\nrepo_gpgcheck=1\ngpgkey=https://keys.openpgp.org/vks/v1/by-keyid/7650C43BBA3C3A2C" > /etc/zypp/repos.d/shiftkey-desktop.repo'
+$ sudo sh -c 'echo -e "[shiftkey]\nname=GitHub Desktop\nbaseurl=https://mirror.mwt.me/ghd/rpm\nenabled=1\ngpgcheck=0\nrepo_gpgcheck=1\ngpgkey=https://mirror.mwt.me/ghd/gpgkey" > /etc/zypp/repos.d/shiftkey-desktop.repo'
 ```
 
 Then install GitHub Desktop:


### PR DESCRIPTION
I added `mirror.mwt.me` as a possible repo option. I tried to keep this stylistically consistent with the rest of the document.

I also offloaded the GPG key download to the mirror. This allows this step to work even if PackageCloud is out of bandwidth. This small file could be hosted anywhere though. It's probably better for security if you put it on your website or something.

Let me know if there's anything you'd like me to revert or do differently.

Closes #647, in response to #657 