### PR TITLE
Change apt source file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ To setup the package repository, run one of these commands:
 
 ```sh
 # if you want to use packagecloud.io
-$ sudo sh -c 'echo "deb [arch=amd64] https://packagecloud.io/shiftkey/desktop/any/ any main" > /etc/apt/sources.list.d/packagecloud-shiftkey-desktop.list'
+$ sudo sh -c 'echo "deb [arch=amd64] https://packagecloud.io/shiftkey/desktop/any/ any main" > /etc/apt/sources.list.d/packagecloud-io-shiftkey-desktop.list'
 
 # if you want to use the US mirror
-$ sudo sh -c 'echo "deb [arch=amd64] https://mirror.mwt.me/ghd/deb/ any main" > /etc/apt/sources.list.d/packagecloud-shiftkey-desktop.list'
+$ sudo sh -c 'echo "deb [arch=amd64] https://mirror.mwt.me/ghd/deb/ any main" > /etc/apt/sources.list.d/packagecloud-mwt-shiftkey-desktop.list'
 ```
 
 Then install GitHub Desktop:


### PR DESCRIPTION
Use different names for different hosts

## Description
Probably a silly change, since an admin would only choose one
