### PR TITLE
Exclude paths from protocol handler callback that end with `github-desktop`

### DIFF
--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -266,7 +266,7 @@ function handlePossibleProtocolLauncherArgs(args: ReadonlyArray<string>) {
     // so we should filter out the program name as well as any parameters that
     // look like arguments to Electron
     const argsWithoutParameters = args.filter(
-      a => a !== 'github-desktop' && !a.startsWith('--')
+      a => !a.endsWith('github-desktop') && !a.startsWith('--')
     )
     if (argsWithoutParameters.length > 0) {
       handleAppURL(argsWithoutParameters[0])


### PR DESCRIPTION
Follow-up to #687 as we should ignore any path ending in `github-desktop`