### PR TITLE
feat: support detecting VsCode in WSL

### DIFF
--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -26,7 +26,7 @@ const editors: ILinuxExternalEditor[] = [
   },
   {
     name: 'Visual Studio Code',
-    paths: ['/usr/share/code/bin/code', '/snap/bin/code', '/usr/bin/code'],
+    paths: ['/usr/share/code/bin/code', '/snap/bin/code', '/usr/bin/code', '/mnt/c/Program Files/Microsoft VS Code/bin/code'],
   },
   {
     name: 'Visual Studio Code (Insiders)',

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -26,7 +26,12 @@ const editors: ILinuxExternalEditor[] = [
   },
   {
     name: 'Visual Studio Code',
-    paths: ['/usr/share/code/bin/code', '/snap/bin/code', '/usr/bin/code', '/mnt/c/Program Files/Microsoft VS Code/bin/code'],
+    paths: [
+      '/usr/share/code/bin/code',
+      '/snap/bin/code',
+      '/usr/bin/code',
+      '/mnt/c/Program Files/Microsoft VS Code/bin/code',
+    ],
   },
   {
     name: 'Visual Studio Code (Insiders)',


### PR DESCRIPTION


## Description
This allows the GitHub desktop that is installed inside WSL to detect the VsCode that is installed on Windows.


## Release notes

- feat: support detecting VsCode in WSL

