### PR TITLE
Adds LXTerminal to terminals and Geany and Mousepad to supported editors

### DIFF
--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -92,7 +92,7 @@ const editors: ILinuxExternalEditor[] = [
     name: 'Geany',
     paths: ['/usr/bin/geany'],
   },
-    {
+  {
     name: 'Mousepad',
     paths: ['/usr/bin/mousepad'],
   },

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -92,6 +92,10 @@ const editors: ILinuxExternalEditor[] = [
     name: 'Geany',
     paths: ['/usr/bin/geany'],
   },
+    {
+    name: 'Mousepad',
+    paths: ['/usr/bin/mousepad'],
+  },
 ]
 
 async function getAvailablePath(paths: string[]): Promise<string | null> {

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -88,6 +88,10 @@ const editors: ILinuxExternalEditor[] = [
     name: 'Notepadqq',
     paths: ['/usr/bin/notepadqq'],
   },
+  {
+    name: 'Geany',
+    paths: ['/usr/bin/geany'],
+  },
 ]
 
 async function getAvailablePath(paths: string[]): Promise<string | null> {

--- a/app/src/lib/shells/linux.ts
+++ b/app/src/lib/shells/linux.ts
@@ -204,6 +204,7 @@ export function launch(
         path,
       ])
     case Shell.LXTerminal:
+      return spawnShell(foundShell.path, ['--working-directory=' + path])
     default:
       return assertNever(shell, `Unknown shell: ${shell}`)
   }

--- a/app/src/lib/shells/linux.ts
+++ b/app/src/lib/shells/linux.ts
@@ -163,7 +163,6 @@ export async function getAvailableShells(): Promise<
     shells.push({ shell: Shell.Kitty, path: kittyPath })
   }
 
-
   if (lxterminalPath) {
     shells.push({ shell: Shell.LXTerminal, path: lxterminalPath })
   }

--- a/app/src/lib/shells/linux.ts
+++ b/app/src/lib/shells/linux.ts
@@ -19,6 +19,7 @@ export enum Shell {
   XFCE = 'XFCE Terminal',
   Alacritty = 'Alacritty',
   Kitty = 'Kitty',
+  LXTerminal = 'LXDE Terminal',
 }
 
 export const Default = Shell.Gnome
@@ -61,6 +62,8 @@ function getShellPath(shell: Shell): Promise<string | null> {
       return getPathIfAvailable('/usr/bin/alacritty')
     case Shell.Kitty:
       return getPathIfAvailable('/usr/bin/kitty')
+    case Shell.LXTerminal:
+      return getPathIfAvailable('/usr/bin/lxterminal')
     default:
       return assertNever(shell, `Unknown shell: ${shell}`)
   }
@@ -84,6 +87,7 @@ export async function getAvailableShells(): Promise<
     xfcePath,
     alacrittyPath,
     kittyPath,
+    lxterminalPath,
   ] = await Promise.all([
     getShellPath(Shell.Gnome),
     getShellPath(Shell.GnomeConsole),
@@ -99,6 +103,7 @@ export async function getAvailableShells(): Promise<
     getShellPath(Shell.XFCE),
     getShellPath(Shell.Alacritty),
     getShellPath(Shell.Kitty),
+    getShellPath(Shell.LXTerminal),
   ])
 
   const shells: Array<IFoundShell<Shell>> = []
@@ -158,6 +163,11 @@ export async function getAvailableShells(): Promise<
     shells.push({ shell: Shell.Kitty, path: kittyPath })
   }
 
+
+  if (lxterminalPath) {
+    shells.push({ shell: Shell.LXTerminal, path: lxterminalPath })
+  }
+
   return shells
 }
 
@@ -193,6 +203,7 @@ export function launch(
         '--directory',
         path,
       ])
+    case Shell.LXTerminal:
     default:
       return assertNever(shell, `Unknown shell: ${shell}`)
   }


### PR DESCRIPTION
## Description
add lxterminal (yes it does need this way of launching, it does not support the `--working-directory path` format, it needs the `=` )

add geany. geany doesn't support opening folders, although it works fine when opening individual files like when right clicking them in the commit history

these are useful for RaspberryPiOS and other LXDE OSs where these are the defaults and other options are not preinstalled