### PR TITLE
add armv7l support to scripts

### DIFF
--- a/script/build.ts
+++ b/script/build.ts
@@ -156,7 +156,11 @@ function packageApp() {
       targetArch = os.arch()
     }
 
-    if (targetArch === 'arm64' || targetArch === 'x64' || targetArch === 'armv7l') {
+    if (
+      targetArch === 'arm64' ||
+      targetArch === 'x64' ||
+      targetArch === 'armv7l'
+    ) {
       return targetArch
     }
 

--- a/script/build.ts
+++ b/script/build.ts
@@ -156,7 +156,7 @@ function packageApp() {
       targetArch = os.arch()
     }
 
-    if (targetArch === 'arm64' || targetArch === 'x64') {
+    if (targetArch === 'arm64' || targetArch === 'x64' || targetArch === 'armv7l') {
       return targetArch
     }
 

--- a/script/dist-info.ts
+++ b/script/dist-info.ts
@@ -143,17 +143,21 @@ export function getReleaseSHA() {
   return pieces[2]
 }
 
-export function getDistArchitecture(): 'arm64' | 'x64' {
+export function getDistArchitecture(): 'arm64' | 'x64' | 'armv7l' {
   // If a specific npm_config_arch is set, we use that one instead of the OS arch (to support cross compilation)
   if (
     process.env.npm_config_arch === 'arm64' ||
-    process.env.npm_config_arch === 'x64'
+    process.env.npm_config_arch === 'x64' ||
+    process.env.npm_config_arch === 'armv7l'
   ) {
     return process.env.npm_config_arch
   }
 
   if (process.arch === 'arm64') {
     return 'arm64'
+  }
+  if (process.arch === 'armv7l') {
+    return 'armv7l'
   }
 
   // TODO: Check if it's x64 running on an arm64 Windows with IsWow64Process2

--- a/script/package-debian.ts
+++ b/script/package-debian.ts
@@ -16,7 +16,7 @@ type DebianOptions = {
   // required
   src: string
   dest: string
-  arch: 'amd64' | 'i386' | 'arm64'
+  arch: 'amd64' | 'i386' | 'arm64' | 'armhf'
   // optional
   description?: string
   productDescription?: string


### PR DESCRIPTION
Assists with https://github.com/shiftkey/desktop/issues/251

## Description
adds armv7l as necessary to buildscripts. There is more work that needs to be done to actually build locally on armv7l systems, as currently the windows `electron-winstaller` still installs on linux systems. this prevents building as `electron-winstaller` looks for a windows arm32 binary which does not exist. to test this, I had to fully remove windows building. the `package.json`. and `script/package.ts` will need to be reworked to not require these windows only dependencies when run on linux

the changes I made to the package-*.ts scripts will also need to be changed to allow for build time customization (instead of hardcoding them to the new values)

to help with the mapping:

deb requires: armhf or arm64
appimage requires: --armv7l or --arm64
rpm requires: armv7l or aarch64

app/src/lib/get-architecture.ts should also be updated but I'm not sure the correct format for that

you can find my arm64 and armhf manually created test builds here: https://github.com/theofficialgman/testing/releases/tag/github-desktop
(with builds for dugite-native as well)