### PR TITLE
Add support for detecting PhpStorm editor

### DIFF
--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -96,6 +96,9 @@ const editors: ILinuxExternalEditor[] = [
     name: 'Mousepad',
     paths: ['/usr/bin/mousepad'],
   },
+  {
+    name: 'IntelliJ PhpStorm',
+    paths: ['/snap/bin/phpstorm'],
 ]
 
 async function getAvailablePath(paths: string[]): Promise<string | null> {

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -99,6 +99,7 @@ const editors: ILinuxExternalEditor[] = [
   {
     name: 'IntelliJ PhpStorm',
     paths: ['/snap/bin/phpstorm'],
+  },
 ]
 
 async function getAvailablePath(paths: string[]): Promise<string | null> {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #716 

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
This only adds for snap, if you install it without snap (with an archive), it can be anywhere so yea.