### PR TITLE
Update package scripts for multiple architectures

### DIFF
--- a/script/package-debian.ts
+++ b/script/package-debian.ts
@@ -11,12 +11,25 @@ import { getDistPath, getDistRoot } from './dist-info'
 
 const distRoot = getDistRoot()
 
+let arch_deb
+switch (process.arch) {
+  case 'x64':
+    arch_deb = 'amd64'
+    break
+  case 'arm':
+    arch_deb = 'armhf'
+    break
+  case 'arm64':
+    arch_deb = 'arm64'
+    break
+}
+
 // best guess based on documentation
 type DebianOptions = {
   // required
   src: string
   dest: string
-  arch: 'amd64' | 'i386' | 'arm64' | 'armhf'
+  arch: string
   // optional
   description?: string
   productDescription?: string
@@ -39,7 +52,7 @@ type DebianOptions = {
 const options: DebianOptions = {
   src: getDistPath(),
   dest: distRoot,
-  arch: 'amd64',
+  arch: `${arch_deb}`,
   description: 'Simple collaboration from your desktop',
   productDescription:
     'This is the unofficial port of GitHub Desktop for Linux distributions',

--- a/script/package-electron-builder.ts
+++ b/script/package-electron-builder.ts
@@ -9,6 +9,24 @@ const globPromise = promisify(glob)
 
 import { getDistPath, getDistRoot } from './dist-info'
 
+let arch_appimage = ''
+switch (process.arch) {
+  case 'x64':
+    console.log('This is an x86_64 system')
+    arch_appimage = '--x64'
+    break
+  case 'arm':
+    console.log('This is an ARM32 system')
+    arch_appimage = '--armv7l'
+    break
+  case 'arm64':
+    console.log('This is an ARM64 system')
+    arch_appimage = '--arm64'
+    break
+  default:
+    console.log('This architecture is unknown or not supported.')
+}
+
 export async function packageElectronBuilder(): Promise<Array<string>> {
   const distPath = getDistPath()
   const distRoot = getDistRoot()
@@ -27,7 +45,7 @@ export async function packageElectronBuilder(): Promise<Array<string>> {
     'build',
     '--prepackaged',
     distPath,
-    '--x64',
+    `${arch_appimage}`,
     '--config',
     configPath,
   ]

--- a/script/package-redhat.ts
+++ b/script/package-redhat.ts
@@ -11,12 +11,25 @@ import { getDistPath, getDistRoot } from './dist-info'
 
 const distRoot = getDistRoot()
 
+let arch_rpm = ''
+switch (process.arch) {
+  case 'x64':
+    arch_rpm = 'x86_64'
+    break
+  case 'arm':
+    arch_rpm = 'armv7l'
+    break
+  case 'arm64':
+    arch_rpm = 'aarch64'
+    break
+}
+
 // best guess based on documentation
 type RedhatOptions = {
   // required
   src: string
   dest: string
-  arch: 'x86_64'
+  arch: string
   // optional
   description?: string
   productDescription?: string
@@ -36,7 +49,7 @@ type RedhatOptions = {
 const options: RedhatOptions = {
   src: getDistPath(),
   dest: distRoot,
-  arch: 'x86_64',
+  arch: `${arch_rpm}`,
   description: 'Simple collaboration from your desktop',
   productDescription:
     'This is the unofficial port of GitHub Desktop for Linux distributions',


### PR DESCRIPTION
does some work on https://github.com/shiftkey/desktop/issues/251

## Description

changes the hardcoding of a single architecture to an architecture set at build time dependent on the running process architecture.

## Notes

as I have said before, I am not a programmer, so if this syntax is horrible I am sorry. It does work however and means that arm64 linux no longer needs any local patching to build (besides building and shimming in dugite-native). This also makes it easier to build armhf linux (though that is still more difficult since the windows node dependencies and scripting has to be fully removed due to winstaller still being installed on linux)
