### PR TITLE
allow for packaging parameters to be derived from `process.arch`

### DIFF
--- a/script/package-debian.ts
+++ b/script/package-debian.ts
@@ -9,6 +9,17 @@ import { rename } from 'fs-extra'
 import { getVersion } from '../app/package-info'
 import { getDistPath, getDistRoot } from './dist-info'
 
+function getArchitecture() {
+  switch (process.arch) {
+    case 'arm64':
+      return 'arm64'
+    case 'arm':
+      return 'armhf'
+    default:
+      return 'amd64'
+  }
+}
+
 const distRoot = getDistRoot()
 
 // best guess based on documentation
@@ -39,7 +50,7 @@ type DebianOptions = {
 const options: DebianOptions = {
   src: getDistPath(),
   dest: distRoot,
-  arch: 'amd64',
+  arch: getArchitecture(),
   description: 'Simple collaboration from your desktop',
   productDescription:
     'This is the unofficial port of GitHub Desktop for Linux distributions',

--- a/script/package-electron-builder.ts
+++ b/script/package-electron-builder.ts
@@ -9,6 +9,17 @@ const globPromise = promisify(glob)
 
 import { getDistPath, getDistRoot } from './dist-info'
 
+function getArchitecture() {
+  switch (process.arch) {
+    case 'arm64':
+      return '--arm64'
+    case 'arm':
+      return '--armv7l'
+    default:
+      return '--x64'
+  }
+}
+
 export async function packageElectronBuilder(): Promise<Array<string>> {
   const distPath = getDistPath()
   const distRoot = getDistRoot()
@@ -27,7 +38,7 @@ export async function packageElectronBuilder(): Promise<Array<string>> {
     'build',
     '--prepackaged',
     distPath,
-    '--x64',
+    getArchitecture(),
     '--config',
     configPath,
   ]

--- a/script/package-redhat.ts
+++ b/script/package-redhat.ts
@@ -9,6 +9,17 @@ import { rename } from 'fs-extra'
 import { getVersion } from '../app/package-info'
 import { getDistPath, getDistRoot } from './dist-info'
 
+function getArchitecture() {
+  switch (process.arch) {
+    case 'arm64':
+      return 'aarch64'
+    case 'arm':
+      return 'armv7l'
+    default:
+      return 'x86_64'
+  }
+}
+
 const distRoot = getDistRoot()
 
 // best guess based on documentation
@@ -16,7 +27,7 @@ type RedhatOptions = {
   // required
   src: string
   dest: string
-  arch: 'x86_64'
+  arch: string
   // optional
   description?: string
   productDescription?: string
@@ -36,7 +47,7 @@ type RedhatOptions = {
 const options: RedhatOptions = {
   src: getDistPath(),
   dest: distRoot,
-  arch: 'x86_64',
+  arch: getArchitecture(),
   description: 'Simple collaboration from your desktop',
   productDescription:
     'This is the unofficial port of GitHub Desktop for Linux distributions',


### PR DESCRIPTION
Supersedes #763

## Description

This is a more succinct version of #763, defaulting to AMD64 unless one of the ARM-based architectures is found.