### PR TITLE
Fix args processing on first launch on linux

### DIFF
--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -151,6 +151,10 @@ if (__WIN32__ && process.argv.length > 1) {
   }
 }
 
+if (__LINUX__ && process.argv.length > 1) {
+  handlePossibleProtocolLauncherArgs(process.argv)
+}
+
 initializeDesktopNotifications()
 
 function handleAppURL(url: string) {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #620

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
On linux, on first launch of github desktop, it ignores any passed command line arguments. If a instance is already running, and you run the command again, it processes 2nd (and subsequent) launches' command line arguments. This PR adds a call so that it processes args on first launch too. More details at linked issue #620.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: Fix `github .` command not opening or adding current folder as repository on first launch.
