### PR TITLE
refresh docs to move away from PackageCloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Arch Linux users can install GitHub Desktop from the [AUR](https://aur.archlinux
 
 `gnome-keyring` is required and the daemon must be launched either at login or when the X server is started. Normally this is handled by a display manager, but in other cases following the instructions found on the [Arch Wiki](https://wiki.archlinux.org/index.php/GNOME/Keyring#Using_the_keyring_outside_GNOME) will fix the issue of not being able to save login credentials.
 
-### Cross-Distribution
+### Cross-Distribution Packages
 
 GitHub Desktop is also available cross-platform as a [Flatpak](https://github.com/flathub/io.github.shiftey.Desktop) and [AppImage](https://appimage.github.io/GitHubDesktop/).
 

--- a/README.md
+++ b/README.md
@@ -46,15 +46,15 @@ releases from this repository.
 #### [@shiftkey](https://github.com/shiftkey) package feed
 
 ```
-$ wget -qO - https://apt.packages.shiftkey.dev/gpg.key | sudo tee /etc/apt/trusted.gpg.d/shiftkey-packages.asc > /dev/null
-$ sudo sh -c 'echo "deb [arch=amd64] https://apt.packages.shiftkey.dev/ubuntu/ any main" > /etc/apt/sources.list.d/shiftkey-packages-desktop.list'
+$ wget -qO - https://apt.packages.shiftkey.dev/gpg.key | gpg --dearmor | sudo tee /etc/apt/keyrings/shiftkey-packages.asc > /dev/null
+$ sudo sh -c 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/shiftkey-packages.gpg] https://apt.packages.shiftkey.dev/ubuntu/ any main" > /etc/apt/sources.list.d/shiftkey-packages.list'
 ```
 
 #### [@mwt](https://github.com/mwt) package feed
 
 ```sh
-$ wget -qO - https://mirror.mwt.me/ghd/gpgkey | sudo tee /etc/apt/trusted.gpg.d/mwt-desktop.asc > /dev/null
-$ sudo sh -c 'echo "deb [arch=amd64] https://mirror.mwt.me/ghd/deb/ any main" > /etc/apt/sources.list.d/mwt-packages-desktop.list'
+$ wget -qO - https://mirror.mwt.me/ghd/gpgkey | gpg --dearmor | sudo tee /etc/apt/keyrings/mwt-desktop.asc > /dev/null
+$ sudo sh -c 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/mwt-desktop.gpg] https://mirror.mwt.me/ghd/deb/ any main" > /etc/apt/sources.list.d/mwt-packages-desktop.list'
 ```
 
 #### Installation

--- a/README.md
+++ b/README.md
@@ -43,15 +43,15 @@ releases from this repository.
 #### [@shiftkey](https://github.com/shiftkey) package feed
 
 ```
-$ wget -qO - https://apt.packages.shiftkey.dev/gpg.key | gpg --dearmor | sudo tee /etc/apt/keyrings/shiftkey-packages.asc > /dev/null
-$ sudo sh -c 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/shiftkey-packages.gpg] https://apt.packages.shiftkey.dev/ubuntu/ any main" > /etc/apt/sources.list.d/shiftkey-packages.list'
+wget -qO - https://apt.packages.shiftkey.dev/gpg.key | gpg --dearmor | sudo tee /etc/apt/keyrings/shiftkey-packages.asc > /dev/null
+sudo sh -c 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/shiftkey-packages.gpg] https://apt.packages.shiftkey.dev/ubuntu/ any main" > /etc/apt/sources.list.d/shiftkey-packages.list'
 ```
 
 #### [@mwt](https://github.com/mwt) package feed
 
 ```sh
-$ wget -qO - https://mirror.mwt.me/ghd/gpgkey | gpg --dearmor | sudo tee /etc/apt/keyrings/mwt-desktop.asc > /dev/null
-$ sudo sh -c 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/mwt-desktop.gpg] https://mirror.mwt.me/ghd/deb/ any main" > /etc/apt/sources.list.d/mwt-desktop.list'
+wget -qO - https://mirror.mwt.me/ghd/gpgkey | gpg --dearmor | sudo tee /etc/apt/keyrings/mwt-desktop.asc > /dev/null
+sudo sh -c 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/mwt-desktop.gpg] https://mirror.mwt.me/ghd/deb/ any main" > /etc/apt/sources.list.d/mwt-desktop.list'
 ```
 
 #### Installation
@@ -59,7 +59,7 @@ $ sudo sh -c 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/mwt-desktop.gpg]
 Once you have a feed configured, run this command to install the application:
 
 ```sh
-$ sudo apt update && sudo apt install github-desktop
+sudo apt update && sudo apt install github-desktop
 ```
 
 ## Red Hat/CentOS/Fedora users
@@ -71,15 +71,15 @@ releases from this repository.
 ### [@shiftkey](https://github.com/shiftkey) package feed
 
 ```
-$ sudo rpm --import https://rpm.packages.shiftkey.dev/gpg.key
-$ sudo sh -c 'echo -e "[shiftkey-packages]\nname=GitHub Desktop\nbaseurl=https://rpm.packages.shiftkey.dev/rpm/\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\ngpgkey=https://rpm.packages.shiftkey.dev/gpg.key" > /etc/yum.repos.d/shiftkey-packages.repo'
+sudo rpm --import https://rpm.packages.shiftkey.dev/gpg.key
+sudo sh -c 'echo -e "[shiftkey-packages]\nname=GitHub Desktop\nbaseurl=https://rpm.packages.shiftkey.dev/rpm/\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\ngpgkey=https://rpm.packages.shiftkey.dev/gpg.key" > /etc/yum.repos.d/shiftkey-packages.repo'
 ```
 
 ### [@mwt](https://github.com/mwt) package feed
 
 ```sh
-$ sudo rpm --import https://mirror.mwt.me/ghd/gpgkey
-$ sudo sh -c 'echo -e "[shiftkey]\nname=GitHub Desktop\nbaseurl=https://mirror.mwt.me/ghd/rpm\nenabled=1\ngpgcheck=0\nrepo_gpgcheck=1\ngpgkey=https://mirror.mwt.me/ghd/gpgkey" > /etc/yum.repos.d/mwt-packages-desktop.repo'
+sudo rpm --import https://mirror.mwt.me/ghd/gpgkey
+sudo sh -c 'echo -e "[shiftkey]\nname=GitHub Desktop\nbaseurl=https://mirror.mwt.me/ghd/rpm\nenabled=1\ngpgcheck=0\nrepo_gpgcheck=1\ngpgkey=https://mirror.mwt.me/ghd/gpgkey" > /etc/yum.repos.d/mwt-packages-desktop.repo'
 ```
 
 ### Installation
@@ -88,10 +88,10 @@ Once you have a feed configured, run this command to install the application:
 
 ```sh
 # if yum is your package manager
-$ sudo yum install github-desktop
+sudo yum install github-desktop
 
 # if dnf is your package manager
-$ sudo dnf install github-desktop
+sudo dnf install github-desktop
 ```
 
 ## OpenSUSE users
@@ -103,15 +103,15 @@ releases from this repository.
 ### [@shiftkey](https://github.com/shiftkey) package feed
 
 ```
-$ sudo rpm --import https://rpm.packages.shiftkey.dev/gpg.key
-$ sudo sh -c 'echo -e "[shiftkey-packages]\nname=GitHub Desktop\nbaseurl=https://rpm.packages.shiftkey.dev/rpm/\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\ngpgkey=https://rpm.packages.shiftkey.dev/gpg.key" > /etc/yum.repos.d/shiftkey-packages.repo'
+sudo rpm --import https://rpm.packages.shiftkey.dev/gpg.key
+sudo sh -c 'echo -e "[shiftkey-packages]\nname=GitHub Desktop\nbaseurl=https://rpm.packages.shiftkey.dev/rpm/\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\ngpgkey=https://rpm.packages.shiftkey.dev/gpg.key" > /etc/yum.repos.d/shiftkey-packages.repo'
 ```
 
 ### [@mwt](https://github.com/mwt) package feed
 
 ```sh
-$ sudo rpm --import https://mirror.mwt.me/ghd/gpgkey
-$ sudo sh -c 'echo -e "[shiftkey]\nname=GitHub Desktop\nbaseurl=https://mirror.mwt.me/ghd/rpm\nenabled=1\ngpgcheck=0\nrepo_gpgcheck=1\ngpgkey=https://mirror.mwt.me/ghd/gpgkey" > /etc/yum.repos.d/mwt-packages.repo'
+sudo rpm --import https://mirror.mwt.me/ghd/gpgkey
+sudo sh -c 'echo -e "[shiftkey]\nname=GitHub Desktop\nbaseurl=https://mirror.mwt.me/ghd/rpm\nenabled=1\ngpgcheck=0\nrepo_gpgcheck=1\ngpgkey=https://mirror.mwt.me/ghd/gpgkey" > /etc/yum.repos.d/mwt-packages.repo'
 ```
 
 ### Installation
@@ -119,7 +119,7 @@ $ sudo sh -c 'echo -e "[shiftkey]\nname=GitHub Desktop\nbaseurl=https://mirror.m
 Once you have a feed configured, run this command to install the application:
 
 ```sh
-$ sudo zypper ref && sudo zypper in github-desktop
+sudo zypper ref && sudo zypper in github-desktop
 ```
 
 ## Other Distributions

--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ releases from this repository.
 
 ```
 wget -qO - https://apt.packages.shiftkey.dev/gpg.key | gpg --dearmor | sudo tee /etc/apt/keyrings/shiftkey-packages.asc > /dev/null
-sudo sh -c 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/shiftkey-packages.gpg] https://apt.packages.shiftkey.dev/ubuntu/ any main" > /etc/apt/sources.list.d/shiftkey-packages.list'
+sudo sh -c 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/shiftkey-packages.asc] https://apt.packages.shiftkey.dev/ubuntu/ any main" > /etc/apt/sources.list.d/shiftkey-packages.list'
 ```
 
 #### [@mwt](https://github.com/mwt) package feed
 
 ```sh
 wget -qO - https://mirror.mwt.me/ghd/gpgkey | gpg --dearmor | sudo tee /etc/apt/keyrings/mwt-desktop.asc > /dev/null
-sudo sh -c 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/mwt-desktop.gpg] https://mirror.mwt.me/ghd/deb/ any main" > /etc/apt/sources.list.d/mwt-desktop.list'
+sudo sh -c 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/mwt-desktop.asc] https://mirror.mwt.me/ghd/deb/ any main" > /etc/apt/sources.list.d/mwt-desktop.list'
 ```
 
 #### Installation

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ $ sudo sh -c 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/shiftkey-package
 
 ```sh
 $ wget -qO - https://mirror.mwt.me/ghd/gpgkey | gpg --dearmor | sudo tee /etc/apt/keyrings/mwt-desktop.asc > /dev/null
-$ sudo sh -c 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/mwt-desktop.gpg] https://mirror.mwt.me/ghd/deb/ any main" > /etc/apt/sources.list.d/mwt-packages-desktop.list'
+$ sudo sh -c 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/mwt-desktop.gpg] https://mirror.mwt.me/ghd/deb/ any main" > /etc/apt/sources.list.d/mwt-desktop.list'
 ```
 
 #### Installation
@@ -74,7 +74,7 @@ releases from this repository.
 ### [@shiftkey](https://github.com/shiftkey) package feed
 
 ```
-$ sudo rpm --import https://apt.packages.shiftkey.dev/gpg.key
+$ sudo rpm --import https://rpm.packages.shiftkey.dev/gpg.key
 $ sudo sh -c 'echo -e "[shiftkey-packages]\nname=GitHub Desktop\nbaseurl=https://rpm.packages.shiftkey.dev/rpm/\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\ngpgkey=https://rpm.packages.shiftkey.dev/gpg.key" > /etc/yum.repos.d/shiftkey-packages.repo'
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ uses [React](https://reactjs.org/).
 This repository contains specific patches on top of the upstream
 `desktop/desktop` repository to support Linux usage.
 
-It also hosts preview packages for various Linux distributions:
+It also publishes releases for various Linux distributions:
 
  - AppImage (`.AppImage`)
  - Debian (`.deb`)
@@ -35,9 +35,9 @@ help out with testing on your distribution.
 ## Installation via package manager
 
 You can use your operating system's package manager to install `github-desktop` and
-keep it up to date on Debian/RPM based distributions.
+keep it up to date on Debian and RPM-based distributions.
 
-### Setup for Debian/Ubuntu users
+### Debian/Ubuntu users
 
 There are two APT package feeds available, both hosted in the US. You only need
 to add one or the other here, as both of these are generated based on the
@@ -65,7 +65,7 @@ Once you have a feed configured, run this command to install the application:
 $ sudo apt update && sudo apt install github-desktop
 ```
 
-## Setup for Red Hat/CentOS/Fedora users
+## Red Hat/CentOS/Fedora users
 
 There are two RPM package feeds available, both hosted in the US. You only need
 to add one or the other here, as both of these are generated based on the
@@ -97,7 +97,7 @@ $ sudo yum install github-desktop
 $ sudo dnf install github-desktop
 ```
 
-## Setup for OpenSUSE users
+## OpenSUSE users
 
 There are two RPM package feeds available, both hosted in the US. You only need
 to add one or the other here, as both of these are generated based on the

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ It also publishes [releases](https://github.com/shiftkey/desktop/releases) for v
 You can use your operating system's package manager to install `github-desktop` and
 keep it up to date on Debian and RPM-based distributions.
 
-### Debian/Ubuntu users
+### Debian/Ubuntu
 
 There are two APT package feeds available, both hosted in the US. You only need
 to add one or the other here, as both of these are generated based on the
@@ -62,7 +62,7 @@ Once you have a feed configured, run this command to install the application:
 sudo apt update && sudo apt install github-desktop
 ```
 
-## Red Hat/CentOS/Fedora users
+## Red Hat/CentOS/Fedora/OpenSUSE
 
 There are two RPM package feeds available, both hosted in the US. You only need
 to add one or the other here, as both of these are generated based on the
@@ -92,33 +92,8 @@ sudo yum install github-desktop
 
 # if dnf is your package manager
 sudo dnf install github-desktop
-```
 
-## OpenSUSE users
-
-There are two RPM package feeds available, both hosted in the US. You only need
-to add one or the other here, as both of these are generated based on the
-releases from this repository.
-
-### [@shiftkey](https://github.com/shiftkey) package feed
-
-```
-sudo rpm --import https://rpm.packages.shiftkey.dev/gpg.key
-sudo sh -c 'echo -e "[shiftkey-packages]\nname=GitHub Desktop\nbaseurl=https://rpm.packages.shiftkey.dev/rpm/\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\ngpgkey=https://rpm.packages.shiftkey.dev/gpg.key" > /etc/yum.repos.d/shiftkey-packages.repo'
-```
-
-### [@mwt](https://github.com/mwt) package feed
-
-```sh
-sudo rpm --import https://mirror.mwt.me/ghd/gpgkey
-sudo sh -c 'echo -e "[shiftkey]\nname=GitHub Desktop\nbaseurl=https://mirror.mwt.me/ghd/rpm\nenabled=1\ngpgcheck=0\nrepo_gpgcheck=1\ngpgkey=https://mirror.mwt.me/ghd/gpgkey" > /etc/yum.repos.d/mwt-packages.repo'
-```
-
-### Installation
-
-Once you have a feed configured, run this command to install the application:
-
-```sh
+# if zypper is your package manager
 sudo zypper ref && sudo zypper in github-desktop
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,64 +32,62 @@ It also hosts preview packages for various Linux distributions:
 Check out the [latest releases](https://github.com/shiftkey/desktop/releases) to
 help out with testing on your distribution.
 
-## Repositories
+## Package Feeds
 
 You can use your operating system's package manager to install `github-desktop` and
-keep it up to date on Debian/RPM based distributions. There are two options for this:
+keep it up to date on Debian/RPM based distributions.
 
-* A [PackageCloud](https://packagecloud.io/) repository with excellent global connectivity
-  but very limited bandwidth. This option will stop working each month when the bandwidth
-  limit is reached.
-* A [mirror](https://mattwthomas.com/mirrors/) in the US which has effectively infinite
-  bandwidth and performs well in most regions (especially the Americas and Europe).
+### Setup for Debian/Ubuntu users
 
-PackageCloud, which both options depend on, is not a free service. So, if you can afford to
-help with these costs please [**Sponsor**](https://github.com/sponsors/shiftkey) the project
-using the link in the header.
+There are two APT package feeds available, both hosted in the US. You only need
+to add one or the other here, as both of these are generated based on the
+releases from this repository.
 
-### Debian/Ubuntu distributions
+#### [@shiftkey](https://github.com/shiftkey) package feed
 
-First install our GPG certificate:
-
-```sh
-$ wget -qO - https://mirror.mwt.me/ghd/gpgkey | sudo tee /etc/apt/trusted.gpg.d/shiftkey-desktop.asc > /dev/null
+```
+$ wget -qO - https://apt.packages.shiftkey.dev/gpg.key | sudo tee /etc/apt/trusted.gpg.d/shiftkey-packages.asc > /dev/null
+$ sudo sh -c 'echo "deb [arch=amd64] https://apt.packages.shiftkey.dev/ubuntu/ any main" > /etc/apt/sources.list.d/shiftkey-packages-desktop.list'
 ```
 
-To setup the package repository, run one of these commands:
+#### [@mwt](https://github.com/mwt) package feed
 
 ```sh
-# if you want to use packagecloud.io
-$ sudo sh -c 'echo "deb [arch=amd64] https://packagecloud.io/shiftkey/desktop/any/ any main" > /etc/apt/sources.list.d/packagecloud-shiftkey-desktop.list'
-
-# if you want to use the US mirror
-$ sudo sh -c 'echo "deb [arch=amd64] https://mirror.mwt.me/ghd/deb/ any main" > /etc/apt/sources.list.d/packagecloud-shiftkey-desktop.list'
+$ wget -qO - https://mirror.mwt.me/ghd/gpgkey | sudo tee /etc/apt/trusted.gpg.d/mwt-desktop.asc > /dev/null
+$ sudo sh -c 'echo "deb [arch=amd64] https://mirror.mwt.me/ghd/deb/ any main" > /etc/apt/sources.list.d/mwt-packages-desktop.list'
 ```
 
-Then install GitHub Desktop:
+#### Installation
+
+Once you have a feed configured, run this command to install the application:
 
 ```sh
 $ sudo apt update && sudo apt install github-desktop
 ```
 
-### Red Hat/CentOS/Fedora distributions
+## Setup for Red Hat/CentOS/Fedora users
 
-First install our GPG certificate:
+There are two RPM package feeds available, both hosted in the US. You only need
+to add one or the other here, as both of these are generated based on the
+releases from this repository.
+
+### [@shiftkey](https://github.com/shiftkey) package feed
+
+```
+$ sudo rpm --import https://apt.packages.shiftkey.dev/gpg.key
+$ sudo sh -c 'echo -e "[shiftkey-packages]\nname=GitHub Desktop\nbaseurl=https://rpm.packages.shiftkey.dev/rpm/\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\ngpgkey=https://rpm.packages.shiftkey.dev/gpg.key" > /etc/yum.repos.d/shiftkey-packages.repo'
+```
+
+### [@mwt](https://github.com/mwt) package feed
 
 ```sh
 $ sudo rpm --import https://mirror.mwt.me/ghd/gpgkey
+$ sudo sh -c 'echo -e "[shiftkey]\nname=GitHub Desktop\nbaseurl=https://mirror.mwt.me/ghd/rpm\nenabled=1\ngpgcheck=0\nrepo_gpgcheck=1\ngpgkey=https://mirror.mwt.me/ghd/gpgkey" > /etc/yum.repos.d/mwt-packages-desktop.repo'
 ```
 
-To setup the package repository, run one of these commands:
+### Installation
 
-```sh
-# if you want to use packagecloud.io
-$ sudo sh -c 'echo -e "[shiftkey]\nname=GitHub Desktop\nbaseurl=https://packagecloud.io/shiftkey/desktop/el/7/\$basearch\nenabled=1\ngpgcheck=0\nrepo_gpgcheck=1\ngpgkey=https://mirror.mwt.me/ghd/gpgkey" > /etc/yum.repos.d/shiftkey-desktop.repo'
-
-# if you want to use the US mirror
-$ sudo sh -c 'echo -e "[shiftkey]\nname=GitHub Desktop\nbaseurl=https://mirror.mwt.me/ghd/rpm\nenabled=1\ngpgcheck=0\nrepo_gpgcheck=1\ngpgkey=https://mirror.mwt.me/ghd/gpgkey" > /etc/yum.repos.d/shiftkey-desktop.repo'
-```
-
-Then install GitHub Desktop:
+Once you have a feed configured, run this command to install the application:
 
 ```sh
 # if yum is your package manager
@@ -99,29 +97,31 @@ $ sudo yum install github-desktop
 $ sudo dnf install github-desktop
 ```
 
-### OpenSUSE distribution
+## Setup for OpenSUSE users
 
+There are two RPM package feeds available, both hosted in the US. You only need
+to add one or the other here, as both of these are generated based on the
+releases from this repository.
 
-First install our GPG certificate:
+### [@shiftkey](https://github.com/shiftkey) package feed
+
+```
+$ sudo rpm --import https://apt.packages.shiftkey.dev/gpg.key
+$ sudo sh -c 'echo -e "[shiftkey-packages]\nname=GitHub Desktop\nbaseurl=https://rpm.packages.shiftkey.dev/rpm/\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\ngpgkey=https://rpm.packages.shiftkey.dev/gpg.key" > /etc/yum.repos.d/shiftkey-packages.repo'
+```
+
+### [@mwt](https://github.com/mwt) package feed
 
 ```sh
 $ sudo rpm --import https://mirror.mwt.me/ghd/gpgkey
+$ sudo sh -c 'echo -e "[shiftkey]\nname=GitHub Desktop\nbaseurl=https://mirror.mwt.me/ghd/rpm\nenabled=1\ngpgcheck=0\nrepo_gpgcheck=1\ngpgkey=https://mirror.mwt.me/ghd/gpgkey" > /etc/yum.repos.d/mwt-packages.repo'
 ```
 
-To setup the package repository, run one of these commands:
+### Installation
+
+Once you have a feed configured, run this command to install the application:
 
 ```sh
-# if you want to use packagecloud.io
-$ sudo sh -c 'echo -e "[shiftkey]\nname=GitHub Desktop\nbaseurl=https://packagecloud.io/shiftkey/desktop/el/7/\$basearch\nenabled=1\ngpgcheck=0\nrepo_gpgcheck=1\ngpgkey=https://mirror.mwt.me/ghd/gpgkey" > /etc/zypp/repos.d/shiftkey-desktop.repo'
-
-# if you want to use the US mirror
-$ sudo sh -c 'echo -e "[shiftkey]\nname=GitHub Desktop\nbaseurl=https://mirror.mwt.me/ghd/rpm\nenabled=1\ngpgcheck=0\nrepo_gpgcheck=1\ngpgkey=https://mirror.mwt.me/ghd/gpgkey" > /etc/zypp/repos.d/shiftkey-desktop.repo'
-```
-
-Then install GitHub Desktop:
-
-```sh
-# if zypper is your package manager
 $ sudo zypper ref && sudo zypper in github-desktop
 ```
 
@@ -138,6 +138,10 @@ GitHub Desktop is also available cross-platform as a [Flatpak](https://github.co
 
 If you're having troubles with Desktop, please refer to the [Known issues](docs/known-issues.md#linux)
 document for guidance and workarounds for common limitations.
+
+If your package manager is still trying to reach PackageCloud, refer to the
+[cleanup instructions](docs/known-issues.md#the-packagecloud-package-feed-is-no-longer-working)
+for details about migrating away.
 
 ## More information
 

--- a/README.md
+++ b/README.md
@@ -23,14 +23,11 @@ uses [React](https://reactjs.org/).
 This repository contains specific patches on top of the upstream
 `desktop/desktop` repository to support Linux usage.
 
-It also publishes releases for various Linux distributions:
+It also publishes [releases](https://github.com/shiftkey/desktop/releases) for various Linux distributions:
 
  - AppImage (`.AppImage`)
  - Debian (`.deb`)
  - RPM (`.rpm`)
-
-Check out the [latest releases](https://github.com/shiftkey/desktop/releases) to
-help out with testing on your distribution.
 
 ## Installation via package manager
 
@@ -106,7 +103,7 @@ releases from this repository.
 ### [@shiftkey](https://github.com/shiftkey) package feed
 
 ```
-$ sudo rpm --import https://apt.packages.shiftkey.dev/gpg.key
+$ sudo rpm --import https://rpm.packages.shiftkey.dev/gpg.key
 $ sudo sh -c 'echo -e "[shiftkey-packages]\nname=GitHub Desktop\nbaseurl=https://rpm.packages.shiftkey.dev/rpm/\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\ngpgkey=https://rpm.packages.shiftkey.dev/gpg.key" > /etc/yum.repos.d/shiftkey-packages.repo'
 ```
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ sudo sh -c 'echo -e "[shiftkey-packages]\nname=GitHub Desktop\nbaseurl=https://r
 
 ```sh
 sudo rpm --import https://mirror.mwt.me/ghd/gpgkey
-sudo sh -c 'echo -e "[shiftkey]\nname=GitHub Desktop\nbaseurl=https://mirror.mwt.me/ghd/rpm\nenabled=1\ngpgcheck=0\nrepo_gpgcheck=1\ngpgkey=https://mirror.mwt.me/ghd/gpgkey" > /etc/yum.repos.d/mwt-packages-desktop.repo'
+sudo sh -c 'echo -e "[mwt-packages]\nname=GitHub Desktop\nbaseurl=https://mirror.mwt.me/ghd/rpm\nenabled=1\ngpgcheck=0\nrepo_gpgcheck=1\ngpgkey=https://mirror.mwt.me/ghd/gpgkey" > /etc/yum.repos.d/mwt-packages.repo'
 ```
 
 #### Installation

--- a/README.md
+++ b/README.md
@@ -62,27 +62,27 @@ Once you have a feed configured, run this command to install the application:
 sudo apt update && sudo apt install github-desktop
 ```
 
-## Red Hat/CentOS/Fedora/OpenSUSE
+### Red Hat/CentOS/Fedora/OpenSUSE
 
 There are two RPM package feeds available, both hosted in the US. You only need
 to add one or the other here, as both of these are generated based on the
 releases from this repository.
 
-### [@shiftkey](https://github.com/shiftkey) package feed
+#### [@shiftkey](https://github.com/shiftkey) package feed
 
 ```
 sudo rpm --import https://rpm.packages.shiftkey.dev/gpg.key
 sudo sh -c 'echo -e "[shiftkey-packages]\nname=GitHub Desktop\nbaseurl=https://rpm.packages.shiftkey.dev/rpm/\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\ngpgkey=https://rpm.packages.shiftkey.dev/gpg.key" > /etc/yum.repos.d/shiftkey-packages.repo'
 ```
 
-### [@mwt](https://github.com/mwt) package feed
+#### [@mwt](https://github.com/mwt) package feed
 
 ```sh
 sudo rpm --import https://mirror.mwt.me/ghd/gpgkey
 sudo sh -c 'echo -e "[shiftkey]\nname=GitHub Desktop\nbaseurl=https://mirror.mwt.me/ghd/rpm\nenabled=1\ngpgcheck=0\nrepo_gpgcheck=1\ngpgkey=https://mirror.mwt.me/ghd/gpgkey" > /etc/yum.repos.d/mwt-packages-desktop.repo'
 ```
 
-### Installation
+#### Installation
 
 Once you have a feed configured, run this command to install the application:
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ It also hosts preview packages for various Linux distributions:
 Check out the [latest releases](https://github.com/shiftkey/desktop/releases) to
 help out with testing on your distribution.
 
-## Package Feeds
+## Installation via package manager
 
 You can use your operating system's package manager to install `github-desktop` and
 keep it up to date on Debian/RPM based distributions.

--- a/README.md
+++ b/README.md
@@ -127,12 +127,19 @@ $ sudo zypper ref && sudo zypper in github-desktop
 
 ## Other Distributions
 
-Arch Linux users can install GitHub Desktop from the
-[AUR](https://aur.archlinux.org/packages/github-desktop-bin/).
+### Arch Linux
+
+Arch Linux users can install GitHub Desktop from the [AUR](https://aur.archlinux.org/packages/github-desktop-bin/).
 
 `gnome-keyring` is required and the daemon must be launched either at login or when the X server is started. Normally this is handled by a display manager, but in other cases following the instructions found on the [Arch Wiki](https://wiki.archlinux.org/index.php/GNOME/Keyring#Using_the_keyring_outside_GNOME) will fix the issue of not being able to save login credentials.
 
+### Cross-Distribution
+
 GitHub Desktop is also available cross-platform as a [Flatpak](https://github.com/flathub/io.github.shiftey.Desktop) and [AppImage](https://appimage.github.io/GitHubDesktop/).
+
+### deb-get
+
+Debian/Ubuntu users can also install directly from this repository using [`deb-get`](https://github.com/wimpysworld/deb-get): `deb-get install github-desktop`.
 
 ## Known issues
 

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -231,6 +231,25 @@ If you see an error that says "Not enough resources are available to process thi
 
 ## Linux
 
+### The PackageCloud package feed is no longer working
+
+The PackageCloud feed has been closed down. If you are seeing errors about this you should remove the configuration for this feed and refer to the [README](https://github.com/shiftkey/desktop#repositories)
+for the new settings.
+
+#### APT configuration
+
+```
+$ sudo rm /etc/apt/trusted.gpg.d/shiftkey-desktop.asc
+$ sudo rm /etc/apt/sources.list.d/packagecloud-shiftkey-desktop.list
+```
+
+#### RPM configuration
+
+```
+$ sudo rm /etc/apt/sources.list.d/packagecloud-shiftkey-desktop.list
+```
+
+
 ### I get a white screen when launching Desktop
 
 Electron enables hardware accelerated graphics by default, but some graphics cards have issues with hardware acceleration which means the application will launch successfully but it will be a white screen. If you are running GitHub Desktop within virtualization software like Parallels Desktop, hardware accelerated graphics may not be available.

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -239,16 +239,15 @@ for the new settings.
 #### APT configuration
 
 ```
-$ sudo rm /etc/apt/trusted.gpg.d/shiftkey-desktop.asc
-$ sudo rm /etc/apt/sources.list.d/packagecloud-shiftkey-desktop.list
+sudo rm /etc/apt/trusted.gpg.d/shiftkey-desktop.asc
+sudo rm /etc/apt/sources.list.d/packagecloud-shiftkey-desktop.list
 ```
 
 #### RPM configuration
 
 ```
-$ sudo rm /etc/apt/sources.list.d/packagecloud-shiftkey-desktop.list
+sudo rm /etc/apt/sources.list.d/packagecloud-shiftkey-desktop.list
 ```
-
 
 ### I get a white screen when launching Desktop
 


### PR DESCRIPTION
Closes #278
Closes #795

## Description

Refreshing the README to avoid mentioning PackageCloud, in readiness for turning this off soon.

The docs will refer to the new package feed I've setup (for APT and RPM) and also @mwt's mirrors. The setup should be the same for both feeds.

### Screenshots

 - 📝 [**README.md**](https://github.com/shiftkey/desktop/blob/refresh-docs/README.md)
 - 📝 [**Known Issues.md**](https://github.com/shiftkey/desktop/blob/refresh-docs/docs/known-issues.md#the-packagecloud-package-feed-is-no-longer-working)

## Release notes

Notes: no-notes
