### PR TITLE
patch `electron-installer-redhat` to disable `.build-id` links in directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "yarn test:unit --runInBand && yarn test:script",
     "test:setup": "ts-node -P script/tsconfig.json script/test-setup.ts",
     "test:review": "ts-node  -P script/tsconfig.json script/test-review.ts",
-    "postinstall": "patch-package && ts-node -P script/tsconfig.json script/post-install.ts",
+    "postinstall": "ts-node -P script/tsconfig.json script/post-install.ts",
     "start": "cross-env NODE_ENV=development ts-node -P script/tsconfig.json script/start.ts",
     "start:prod": "cross-env NODE_ENV=production ts-node -P script/tsconfig.json script/start.ts",
     "compile:dev": "cross-env NODE_ENV=development TS_NODE_PROJECT=script/tsconfig.json parallel-webpack --config app/webpack.development.ts",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "yarn test:unit --runInBand && yarn test:script",
     "test:setup": "ts-node -P script/tsconfig.json script/test-setup.ts",
     "test:review": "ts-node  -P script/tsconfig.json script/test-review.ts",
-    "postinstall": "ts-node -P script/tsconfig.json script/post-install.ts",
+    "postinstall": "patch-package && ts-node -P script/tsconfig.json script/post-install.ts",
     "start": "cross-env NODE_ENV=development ts-node -P script/tsconfig.json script/start.ts",
     "start:prod": "cross-env NODE_ENV=production ts-node -P script/tsconfig.json script/start.ts",
     "compile:dev": "cross-env NODE_ENV=development TS_NODE_PROJECT=script/tsconfig.json parallel-webpack --config app/webpack.development.ts",
@@ -164,6 +164,8 @@
     "eslint-plugin-github": "^4.3.7",
     "jest-esm-transformer": "^1.0.0",
     "markdownlint-cli": "^0.32.2",
+    "patch-package": "^6.5.1",
+    "postinstall-postinstall": "^2.1.0",
     "reserved-words": "^0.1.2",
     "tsconfig-paths": "^3.9.0"
   },

--- a/patches/electron-installer-redhat+3.3.0.patch
+++ b/patches/electron-installer-redhat+3.3.0.patch
@@ -1,0 +1,18 @@
+diff --git a/node_modules/electron-installer-redhat/resources/spec.ejs b/node_modules/electron-installer-redhat/resources/spec.ejs
+index 48f1dfd..f443eb5 100644
+--- a/node_modules/electron-installer-redhat/resources/spec.ejs
++++ b/node_modules/electron-installer-redhat/resources/spec.ejs
+@@ -1,4 +1,5 @@
+ %define _binary_payload w<%= compressionLevel %>.xzdio
++%define _build_id_links none
+ 
+ Name: <%= name %>
+ Version: <%= version %>
+@@ -17,7 +18,6 @@ AutoReqProv: no
+ <% print(productDescription)
+ print('\n\n\n') }
+ 
+-
+ %>%install
+ mkdir -p %{buildroot}/usr/
+ cp <%= process.platform === 'darwin' ? '-R' : '-r' %> usr/* %{buildroot}/usr/

--- a/patches/electron-installer-redhat+3.3.0.patch
+++ b/patches/electron-installer-redhat+3.3.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/electron-installer-redhat/resources/spec.ejs b/node_modules/electron-installer-redhat/resources/spec.ejs
-index 48f1dfd..f443eb5 100644
+index 48f1dfd..360aec5 100644
 --- a/node_modules/electron-installer-redhat/resources/spec.ejs
 +++ b/node_modules/electron-installer-redhat/resources/spec.ejs
 @@ -1,4 +1,5 @@
@@ -8,11 +8,3 @@ index 48f1dfd..f443eb5 100644
  
  Name: <%= name %>
  Version: <%= version %>
-@@ -17,7 +18,6 @@ AutoReqProv: no
- <% print(productDescription)
- print('\n\n\n') }
- 
--
- %>%install
- mkdir -p %{buildroot}/usr/
- cp <%= process.platform === 'darwin' ? '-R' : '-r' %> usr/* %{buildroot}/usr/

--- a/script/post-install.ts
+++ b/script/post-install.ts
@@ -69,4 +69,12 @@ findYarnVersion(path => {
   if (result.status !== 0) {
     process.exit(result.status || 1)
   }
+
+  if (process.platform === 'linux') {
+    result = spawnSync('node', getYarnArgs([path, 'patch-package']), options)
+
+    if (result.status !== 0) {
+      process.exit(result.status || 1)
+    }
+  }
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1892,6 +1892,11 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
 abab@^2.0.3, abab@^2.0.5:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
@@ -2857,7 +2862,7 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.1:
+chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.1, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -3209,7 +3214,7 @@ cross-spawn@^5.1.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^6.0.0:
+cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
   integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
@@ -4716,6 +4721,13 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+find-yarn-workspace-root@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz#f47fb8d239c900eb78179aa81b66673eac88f7bd"
+  integrity sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==
+  dependencies:
+    micromatch "^4.0.2"
+
 flat-cache@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
@@ -5867,7 +5879,7 @@ is-windows@^1.0.2:
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
 
-is-wsl@^2.2.0:
+is-wsl@^2.1.1, is-wsl@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
@@ -6715,6 +6727,13 @@ klaw-sync@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-3.0.2.tgz#bf3a5ca463af5aec007201dbe8be7088ef29d067"
   integrity sha512-32bw9y2nKrnpX2LsJnDTBO2TSdOKPbXfQAWl7Lupcc3D0iKkzI/sQDEw1GjkOuTqZEhe+bVxKSlhSRLxyeytcw==
+  dependencies:
+    graceful-fs "^4.1.11"
+
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
   dependencies:
     graceful-fs "^4.1.11"
 
@@ -7649,6 +7668,14 @@ onetime@^5.1.0:
   dependencies:
     mimic-fn "^2.1.0"
 
+open@^7.4.2:
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
+  integrity sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==
+  dependencies:
+    is-docker "^2.0.0"
+    is-wsl "^2.1.1"
+
 opener@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
@@ -7814,6 +7841,26 @@ pascalcase@^0.1.1:
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
 
+patch-package@^6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-6.5.1.tgz#3e5d00c16997e6160291fee06a521c42ac99b621"
+  integrity sha512-I/4Zsalfhc6bphmJTlrLoOcAF87jcxko4q0qsv4bGcurbr8IskEOtdnt9iCmsQVGL1B+iUhSQqweyTLJfCF9rA==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    chalk "^4.1.2"
+    cross-spawn "^6.0.5"
+    find-yarn-workspace-root "^2.0.0"
+    fs-extra "^9.0.0"
+    is-ci "^2.0.0"
+    klaw-sync "^6.0.0"
+    minimist "^1.2.6"
+    open "^7.4.2"
+    rimraf "^2.6.3"
+    semver "^5.6.0"
+    slash "^2.0.0"
+    tmp "^0.0.33"
+    yaml "^1.10.2"
+
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
@@ -7972,6 +8019,11 @@ postcss@^8.4.7:
     nanoid "^3.3.4"
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
+
+postinstall-postinstall@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/postinstall-postinstall/-/postinstall-postinstall-2.1.0.tgz#4f7f77441ef539d1512c40bd04c71b06a4704ca3"
+  integrity sha512-7hQX6ZlZXIoRiWNrbMQaLzUUfH+sSx39u8EJ9HYuDc1kLo9IXKWjM5RSquZN1ad5GnH8CGFM78fsAAQi3OKEEQ==
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -8572,6 +8624,13 @@ rimraf@^2.5.2:
   dependencies:
     glob "^7.0.5"
 
+rimraf@^2.6.3:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
+  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
@@ -8725,7 +8784,7 @@ semver-compare@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
   integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
 
-"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0:
+"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -9510,7 +9569,7 @@ tmp-promise@^3.0.2:
   dependencies:
     tmp "^0.2.0"
 
-tmp@0.0.33:
+tmp@0.0.33, tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
   integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
@@ -10360,6 +10419,11 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
+yaml@^1.10.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
+  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
 yaml@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
Closes #796

## Description

This works around the problem where multiple packages generate the same `.build-id/` directory contents, by passing in the right argument to the `electron-installer-redhat` template.

### Screenshots

Before:

```
$ rpm -qlp /srv/createrepo/GitHubDesktop-linux-3.1.7-linux1.rpm | grep .build-id
/usr/lib/.build-id
/usr/lib/.build-id/0c
/usr/lib/.build-id/0c/c0a6654ccba2233fe9ae923ec3b41fbff88ecf
/usr/lib/.build-id/25
/usr/lib/.build-id/25/ad28b19921d0ed63a7e404a29c712279297b41
/usr/lib/.build-id/32
/usr/lib/.build-id/32/dd851d017dce968296854d769ce2eff5c7b530
/usr/lib/.build-id/42
/usr/lib/.build-id/42/05ff88f87056d6a17255e362a8e13370ff7d5a
/usr/lib/.build-id/42/49e6911dafa4ae6641c876a0e3e2f42774868e
/usr/lib/.build-id/62
/usr/lib/.build-id/62/2d90bb8071e24058983873ec4af167a9e322fd
/usr/lib/.build-id/62/2d90bb8071e24058983873ec4af167a9e322fd.1
/usr/lib/.build-id/63
/usr/lib/.build-id/63/e217fb9027ae8d5a8d70bd647853da7daea90a
/usr/lib/.build-id/7a
/usr/lib/.build-id/7a/2da6ede698c92e9a2ef54b441ba17c60cee0b1
/usr/lib/.build-id/88
/usr/lib/.build-id/88/ad16bea9f62f77d82139e0722f27d311c7abee
/usr/lib/.build-id/8a
/usr/lib/.build-id/8a/f6b68b31ad9fd8aee38e4f1796a6d6ce71380e
/usr/lib/.build-id/8c
/usr/lib/.build-id/8c/1f5a43497013414e8e5affc41b54a1cfc91272
/usr/lib/.build-id/a2
/usr/lib/.build-id/a2/562c52725bb7caa27cd0de814ec368b8c45e7f
/usr/lib/.build-id/a5
/usr/lib/.build-id/a5/924fba24e3ec19cd288fb611d5662b38cb10db
/usr/lib/.build-id/a5/d78522a85bda84f552056496d8b2033003de50
/usr/lib/.build-id/ac
/usr/lib/.build-id/ac/fcf0f9ab97028910bbf224fadce67e8187aaf4
/usr/lib/.build-id/d1
/usr/lib/.build-id/d1/ad5fe2127add07286cfca1f9ccc7e79df037e3
/usr/lib/.build-id/d1/ad5fe2127add07286cfca1f9ccc7e79df037e3.1
/usr/lib/.build-id/da
/usr/lib/.build-id/da/fd4e0728b3453ee89d124aad0501a4dc5b02d0
/usr/lib/.build-id/e7
/usr/lib/.build-id/e7/21f91f7ae8b76bd365648be789d24b337222bc
/usr/lib/.build-id/ee
/usr/lib/.build-id/ee/c35af598d97b68ccecf96f783924c7f3ebc3fb
```

After: no files present

```
$ rpm -qlp dist/GitHubDesktop-linux-3.1.7.rpm| grep .build-id

```

