### PR TITLE
Add support for Flatpak installs of several editors

### DIFF
--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -43,8 +43,8 @@ const editors: ILinuxExternalEditor[] = [
       '/snap/bin/code',
       '/usr/bin/code',
       '/mnt/c/Program Files/Microsoft VS Code/bin/code',
-      '/var/lib/flatpak/app/com.visualstudio.code',
-      '.local/share/flatpak/app/com.visualstudio.code',
+      '/var/lib/flatpak/app/com.visualstudio.code/current/active/export/bin/com.visualstudio.code',
+      '.local/share/flatpak/app/com.visualstudio.code/current/active/export/bin/com.visualstudio.code',
     ],
   },
   {
@@ -52,17 +52,17 @@ const editors: ILinuxExternalEditor[] = [
     paths: [
       '/snap/bin/code-insiders',
       '/usr/bin/code-insiders',
-      '/var/lib/flatpak/app/com.visualstudio.code.insiders',
-      '.local/share/flatpak/app/com.visualstudio.code.insiders'
+      '/var/lib/flatpak/app/com.visualstudio.code.insiders/current/active/export/bin/com.visualstudio.code.insiders',
+      '.local/share/flatpak/app/com.visualstudio.code.insiders/current/active/export/bin/com.visualstudio.code.insiders',
     ],
   },
   {
     name: 'VSCodium',
     paths: [
       '/usr/bin/codium',
-      '/var/lib/flatpak/app/com.vscodium.codium',
+      '/var/lib/flatpak/app/com.vscodium.codium/current/active/export/bin/com.vscodium.codium',
       '/usr/share/vscodium-bin/bin/codium',
-      '.local/share/flatpak/app/com.vscodium.codium',
+      '.local/share/flatpak/app/com.vscodium.codium/current/active/export/bin/com.vscodium.codium',
     ],
   },
   {

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -43,11 +43,18 @@ const editors: ILinuxExternalEditor[] = [
       '/snap/bin/code',
       '/usr/bin/code',
       '/mnt/c/Program Files/Microsoft VS Code/bin/code',
+      '/var/lib/flatpak/app/com.visualstudio.code',
+      '.local/share/flatpak/app/com.visualstudio.code',
     ],
   },
   {
     name: 'Visual Studio Code (Insiders)',
-    paths: ['/snap/bin/code-insiders', '/usr/bin/code-insiders'],
+    paths: [
+      '/snap/bin/code-insiders',
+      '/usr/bin/code-insiders',
+      '/var/lib/flatpak/app/com.visualstudio.code.insiders',
+      '.local/share/flatpak/app/com.visualstudio.code.insiders'
+    ],
   },
   {
     name: 'VSCodium',
@@ -55,6 +62,7 @@ const editors: ILinuxExternalEditor[] = [
       '/usr/bin/codium',
       '/var/lib/flatpak/app/com.vscodium.codium',
       '/usr/share/vscodium-bin/bin/codium',
+      '.local/share/flatpak/app/com.vscodium.codium',
     ],
   },
   {


### PR DESCRIPTION
Closes #885 
Potentially closes #851 and #879 

## Description

- Adds additional path for user Flatpak installation of VS Code
- Adds additional path for system Flatpak installation of VS Code
- Adds additional path for user Flatpak installation of VS Code Insiders
- Adds additional path for system Flatpak installation of VS Code Insiders
- Adds additional path for user Flatpak installation of VS Codium


## Release notes

- Adds support for VS Code Editor as a Flatpak
- Adds support for VS Code Insiders Editor as a Flatpak
- Adds support for VS Codium Editor as a Flatpak

Notes:

There is probably a better way to format this, but I don't know enough about Electron to find those ways, extra input would be great!  

Tested using the produced AppImage and deb file, haven't tested the RPM.