### PR TITLE
remove geany as supported editor because it doesn't work as expected

### DIFF
--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -141,10 +141,6 @@ const editors: ILinuxExternalEditor[] = [
     paths: ['/usr/bin/notepadqq'],
   },
   {
-    name: 'Geany',
-    paths: ['/usr/bin/geany'],
-  },
-  {
     name: 'Mousepad',
     paths: ['/usr/bin/mousepad'],
   },


### PR DESCRIPTION
Closes #871 as this doesn't support opening a directory without additional plugins: https://github.com/geany/geany/issues/2802