### PR TITLE
introduce separate publish step which runs after build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,15 +252,12 @@ jobs:
           echo "---"
           cat ${RELEASE_NOTES_FILE}
           echo "---"
-          echo 'LINUX_RELEASE_NOTES<<EOF' >> $GITHUB_ENV
-          cat ${LINUX_RELEASE_NOTES} >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
 
       - name: Create Release
         uses: softprops/action-gh-release@v1
-        release_name: GitHub Desktop for Linux ${{ env.RELEASE_TAG_WITHOUT_PREFIX }}
-        body: ${{ env.LINUX_RELEASE_NOTES }}
         with:
+          name: GitHub Desktop for Linux ${{ env.RELEASE_TAG_WITHOUT_PREFIX }}
+          body_path: script/release_notes.txt
           files: |
             artifacts/*.AppImage
             artifacts/*.deb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,7 +213,7 @@ jobs:
     name: Create GitHub release
     needs: [build, lint]
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') }}
+    if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,6 @@ jobs:
   publish:
     name: Create GitHub release
     needs: [build, lint]
-    if: matrix.friendlyName == 'Ubuntu' # && contains(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
       - 'linux-release-*'
     tags:
       - 'release-*.*.*-linux*'
+      - 'release-*.*.*-test*'
   pull_request:
     branches:
       - linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,20 +196,6 @@ jobs:
       - name: Package application
         run: yarn run package
         if: ${{ matrix.friendlyName == 'Ubuntu' }}
-      - name: Create Release
-        uses: softprops/action-gh-release@v1
-        if:
-          ${{ matrix.friendlyName == 'Ubuntu' && startsWith(github.ref,
-          'refs/tags/') }}
-        with:
-          files: |
-            dist/*.AppImage
-            dist/*.deb
-            dist/*.rpm
-            dist/*.txt
-          draft: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload output artifacts
         uses: actions/upload-artifact@v3
         if: matrix.friendlyName == 'Ubuntu'
@@ -220,3 +206,55 @@ jobs:
             dist/*.deb
             dist/*.rpm
           retention-days: 5
+
+  publish:
+    name: Create GitHub release
+    needs: [build, lint]
+    if: matrix.friendlyName == 'Ubuntu' # && contains(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: './artifacts'
+
+      - name: Display structure of downloaded files
+        run: ls -R
+        working-directory: './artifacts'
+
+      # TODO: generate release notes
+      #    - pull in default if version matches X.Y.Z-linux1
+      #    - otherwise stub template
+      #    - include checksums of files
+      #    - format versions by architecture
+
+      - name: Generate release notes
+        run: |
+          npm ci
+          node -r ts-node/register script/generate-release-notes.ts "${{ github.workspace }}/artifacts"
+          RELEASE_NOTES_FILE=script/release_notes.txt
+          if [[ ! -f "$RELEASE_NOTES_FILE" ]]; then
+              echo "$RELEASE_NOTES_FILE does not exist. Something might have gone wrong while generating the release notes."
+              exit 1
+          fi
+          echo "Release notes:"
+          echo "---"
+          cat ${RELEASE_NOTES_FILE}
+          echo "---"
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        if: contains(github.ref, 'refs/tags/')
+        with:
+          files: |
+            artifacts/*.AppImage
+            artifacts/*.deb
+            artifacts/*.rpm
+            artifacts/*.txt
+          draft: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,7 @@ jobs:
 
       - name: Generate release notes
         run: |
-          npm ci
+          yarn
           node -r ts-node/register script/generate-release-notes.ts "${{ github.workspace }}/artifacts"
           RELEASE_NOTES_FILE=script/release_notes.txt
           if [[ ! -f "$RELEASE_NOTES_FILE" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,7 @@ jobs:
             dist/*.AppImage
             dist/*.deb
             dist/*.rpm
+            dist/*.sha256
           retention-days: 5
 
   publish:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,7 +242,7 @@ jobs:
       - name: Generate release notes
         run: |
           yarn
-          node -r ts-node/register script/generate-release-notes.ts "${{ github.workspace }}/artifacts" "${{ RELEASE_TAG_WITHOUT_PREFIX }}"
+          node -r ts-node/register script/generate-release-notes.ts "${{ github.workspace }}/artifacts" "${{ env.RELEASE_TAG_WITHOUT_PREFIX }}"
           RELEASE_NOTES_FILE=script/release_notes.txt
           if [[ ! -f "$RELEASE_NOTES_FILE" ]]; then
               echo "$RELEASE_NOTES_FILE does not exist. Something might have gone wrong while generating the release notes."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,7 @@ jobs:
     name: Create GitHub release
     needs: [build, lint]
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/') }}
     permissions:
       contents: write
     steps:
@@ -226,16 +227,21 @@ jobs:
         run: ls -R
         working-directory: './artifacts'
 
+      - name: Get tag name without prefix
+        run: |
+          RELEASE_TAG=${GITHUB_REF/refs\/tags\//}
+          echo "RELEASE_TAG=${RELEASE_TAG}" >> $GITHUB_ENV
+          tagNameWithoutPrefix="${RELEASE_TAG:1}"
+          echo "RELEASE_TAG_WITHOUT_PREFIX=${tagNameWithoutPrefix}" >> $GITHUB_ENV
+
       # TODO: generate release notes
       #    - pull in default if version matches X.Y.Z-linux1
       #    - otherwise stub template
-      #    - include checksums of files
-      #    - format versions by architecture
 
       - name: Generate release notes
         run: |
           yarn
-          node -r ts-node/register script/generate-release-notes.ts "${{ github.workspace }}/artifacts"
+          node -r ts-node/register script/generate-release-notes.ts "${{ github.workspace }}/artifacts" "${{ RELEASE_TAG_WITHOUT_PREFIX }}"
           RELEASE_NOTES_FILE=script/release_notes.txt
           if [[ ! -f "$RELEASE_NOTES_FILE" ]]; then
               echo "$RELEASE_NOTES_FILE does not exist. Something might have gone wrong while generating the release notes."
@@ -245,16 +251,19 @@ jobs:
           echo "---"
           cat ${RELEASE_NOTES_FILE}
           echo "---"
+          echo 'LINUX_RELEASE_NOTES<<EOF' >> $GITHUB_ENV
+          cat ${LINUX_RELEASE_NOTES} >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
 
       - name: Create Release
         uses: softprops/action-gh-release@v1
-        if: contains(github.ref, 'refs/tags/')
+        release_name: GitHub Desktop for Linux ${{ env.RELEASE_TAG_WITHOUT_PREFIX }}
+        body: ${{ env.LINUX_RELEASE_NOTES }}
         with:
           files: |
             artifacts/*.AppImage
             artifacts/*.deb
             artifacts/*.rpm
-            artifacts/*.txt
           draft: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ app/node_modules/
 junit*.xml
 *.swp
 tslint-rules/
+script/release_notes.txt

--- a/script/generate-release-notes.ts
+++ b/script/generate-release-notes.ts
@@ -44,7 +44,7 @@ const shaEntriesByArchitecture: ChecksumGroups = {
   ),
   arm: shaEntries.filter(
     e =>
-      e.filename.includes('-linux-armv71-') ||
+      e.filename.includes('-linux-armv7l-') ||
       e.filename.includes('-linux-armhf-')
   ),
   arm64: shaEntries.filter(

--- a/script/generate-release-notes.ts
+++ b/script/generate-release-notes.ts
@@ -8,7 +8,7 @@ type ChecksumEntry = { filename: string; checksum: string }
 
 type ChecksumGroups = Record<'x64' | 'arm' | 'arm64', Array<ChecksumEntry>>
 
-// 3 architectures * 3 package formats * 2 files (package + checksum file) 
+// 3 architectures * 3 package formats * 2 files (package + checksum file)
 const SUCCESSFUL_RELEASE_FILE_COUNT = 3 * 3 * 2
 
 const Glob = glob.GlobSync
@@ -37,15 +37,30 @@ if (SUCCESSFUL_RELEASE_FILE_COUNT !== countFiles) {
 }
 
 const shaEntriesByArchitecture: ChecksumGroups = {
-  x64: shaEntries.filter(e => e.filename.includes("-linux-x86_64-") || e.filename.includes("-linux-amd64-")),
-  arm: shaEntries.filter(e => e.filename.includes("-linux-armv71-") || e.filename.includes("-linux-armhf-")),
-  arm64: shaEntries.filter(e => e.filename.includes("-linux-aarch64-") || e.filename.includes("-linux-arm64-"))
+  x64: shaEntries.filter(
+    e =>
+      e.filename.includes('-linux-x86_64-') ||
+      e.filename.includes('-linux-amd64-')
+  ),
+  arm: shaEntries.filter(
+    e =>
+      e.filename.includes('-linux-armv71-') ||
+      e.filename.includes('-linux-armhf-')
+  ),
+  arm64: shaEntries.filter(
+    e =>
+      e.filename.includes('-linux-aarch64-') ||
+      e.filename.includes('-linux-arm64-')
+  ),
 }
 
 console.log(`Found ${countFiles} files in artifacts directory`)
 console.log(shaEntriesByArchitecture)
 
-const draftReleaseNotes = generateDraftReleaseNotes([], shaEntriesByArchitecture)
+const draftReleaseNotes = generateDraftReleaseNotes(
+  [],
+  shaEntriesByArchitecture
+)
 const releaseNotesPath = __dirname + '/release_notes.txt'
 
 fs.writeFileSync(releaseNotesPath, draftReleaseNotes, { encoding: 'utf8' })
@@ -80,9 +95,9 @@ function generateDraftReleaseNotes(
 ): string {
   const changelogText = releaseNotesEntries.join('\n')
 
-  const x64Section = shaEntries.x64.map(formatEntry).join('\n');
-  const armSection = shaEntries.arm.map(formatEntry).join('\n');
-  const arm64Section = shaEntries.arm64.map(formatEntry).join('\n');
+  const x64Section = shaEntries.x64.map(formatEntry).join('\n')
+  const armSection = shaEntries.arm.map(formatEntry).join('\n')
+  const arm64Section = shaEntries.arm64.map(formatEntry).join('\n')
 
   const draftReleaseNotes = `${changelogText}
 

--- a/script/generate-release-notes.ts
+++ b/script/generate-release-notes.ts
@@ -29,7 +29,9 @@ if (!releaseTagWithoutPrefix) {
   process.exit(1)
 }
 
-console.log(`Preparing release notes for release tag ${releaseTagWithoutPrefix}`)
+console.log(
+  `Preparing release notes for release tag ${releaseTagWithoutPrefix}`
+)
 
 const files = new Glob(artifactsDir + '/**/*', { nodir: true })
 

--- a/script/generate-release-notes.ts
+++ b/script/generate-release-notes.ts
@@ -118,7 +118,11 @@ function generateDraftReleaseNotes(
 
   const draftReleaseNotes = `${changelogText}
 
-## SHA-256 checksums:
+## Fixes and improvements
+
+TODO
+
+## SHA-256 checksums
 
 ### x64
 

--- a/script/generate-release-notes.ts
+++ b/script/generate-release-notes.ts
@@ -1,0 +1,69 @@
+import * as glob from 'glob'
+import { basename } from 'path'
+import * as fs from 'fs'
+
+// eslint-disable-next-line no-sync
+const Glob = glob.GlobSync
+
+const args = process.argv.slice(2)
+const artifactsDir = args[0]
+
+const files = new Glob(artifactsDir + '/**/*', { nodir: true })
+let countFiles = 0
+const shaEntries: Array<{ filename: string; checksum: string }> = []
+
+for (const file of files.found) {
+  if (file.endsWith('.sha256')) {
+    shaEntries.push(getShaContents(file))
+  }
+
+  countFiles++
+}
+
+console.log(`Found ${countFiles} files in artifacts directory`)
+console.log(shaEntries)
+
+const draftReleaseNotes = generateDraftReleaseNotes([], shaEntries)
+const releaseNotesPath = __dirname + '/release_notes.txt'
+
+// eslint-disable-next-line no-sync
+fs.writeFileSync(releaseNotesPath, draftReleaseNotes, { encoding: 'utf8' })
+
+console.log(
+  `✅ All done! The release notes have been written to ${releaseNotesPath}`
+)
+
+/**
+ * Returns the filename (excluding .sha256) and its contents (a SHA256 checksum).
+ */
+function getShaContents(filePath: string): {
+  filename: string
+  checksum: string
+} {
+  const filename = basename(filePath).slice(0, -7)
+  // eslint-disable-next-line no-sync
+  const checksum = fs.readFileSync(filePath, 'utf8')
+
+  return { filename, checksum }
+}
+
+/**
+ * Takes the release notes entries and the SHA entries, then merges them into the full draft release notes ✨
+ */
+function generateDraftReleaseNotes(
+  releaseNotesEntries: Array<string>,
+  shaEntries: Array<{ filename: string; checksum: string }>
+): string {
+  const changelogText = releaseNotesEntries.join('\n')
+
+  const fileList = shaEntries.map(e => `**${e.filename}**\n${e.checksum}\n`)
+  const fileListText = fileList.join('\n')
+
+  const draftReleaseNotes = `${changelogText}
+
+## SHA-256 hashes:
+
+${fileListText}`
+
+  return draftReleaseNotes
+}

--- a/script/generate-release-notes.ts
+++ b/script/generate-release-notes.ts
@@ -1,16 +1,25 @@
+/* eslint-disable no-sync */
+
 const glob = require('glob')
 const { basename } = require('path')
 const fs = require('fs')
 
-// eslint-disable-next-line no-sync
+type ChecksumEntry = { filename: string; checksum: string }
+
+type ChecksumGroups = Record<'x64' | 'arm' | 'arm64', Array<ChecksumEntry>>
+
+// 3 architectures * 3 package formats * 2 files (package + checksum file) 
+const SUCCESSFUL_RELEASE_FILE_COUNT = 3 * 3 * 2
+
 const Glob = glob.GlobSync
 
 const args = process.argv.slice(2)
 const artifactsDir = args[0]
 
 const files = new Glob(artifactsDir + '/**/*', { nodir: true })
+
 let countFiles = 0
-const shaEntries: Array<{ filename: string; checksum: string }> = []
+const shaEntries = new Array<ChecksumEntry>()
 
 for (const file of files.found) {
   if (file.endsWith('.sha256')) {
@@ -20,13 +29,25 @@ for (const file of files.found) {
   countFiles++
 }
 
-console.log(`Found ${countFiles} files in artifacts directory`)
-console.log(shaEntries)
+if (SUCCESSFUL_RELEASE_FILE_COUNT !== countFiles) {
+  console.error(
+    `🔴 Artifacts folder has ${countFiles} assets, expecting ${SUCCESSFUL_RELEASE_FILE_COUNT}. Please check the GH Actions artifacts to see which are missing.`
+  )
+  process.exit(1)
+}
 
-const draftReleaseNotes = generateDraftReleaseNotes([], shaEntries)
+const shaEntriesByArchitecture: ChecksumGroups = {
+  x64: shaEntries.filter(e => e.filename.includes("-linux-x86_64-") || e.filename.includes("-linux-amd64-")),
+  arm: shaEntries.filter(e => e.filename.includes("-linux-armv71-") || e.filename.includes("-linux-armhf-")),
+  arm64: shaEntries.filter(e => e.filename.includes("-linux-aarch64-") || e.filename.includes("-linux-arm64-"))
+}
+
+console.log(`Found ${countFiles} files in artifacts directory`)
+console.log(shaEntriesByArchitecture)
+
+const draftReleaseNotes = generateDraftReleaseNotes([], shaEntriesByArchitecture)
 const releaseNotesPath = __dirname + '/release_notes.txt'
 
-// eslint-disable-next-line no-sync
 fs.writeFileSync(releaseNotesPath, draftReleaseNotes, { encoding: 'utf8' })
 
 console.log(
@@ -41,10 +62,13 @@ function getShaContents(filePath: string): {
   checksum: string
 } {
   const filename = basename(filePath).slice(0, -7)
-  // eslint-disable-next-line no-sync
   const checksum = fs.readFileSync(filePath, 'utf8')
 
   return { filename, checksum }
+}
+
+function formatEntry(e: ChecksumEntry): string {
+  return `**${e.filename}**\n${e.checksum}\n`
 }
 
 /**
@@ -52,18 +76,29 @@ function getShaContents(filePath: string): {
  */
 function generateDraftReleaseNotes(
   releaseNotesEntries: Array<string>,
-  shaEntries: Array<{ filename: string; checksum: string }>
+  shaEntries: ChecksumGroups
 ): string {
   const changelogText = releaseNotesEntries.join('\n')
 
-  const fileList = shaEntries.map(e => `**${e.filename}**\n${e.checksum}\n`)
-  const fileListText = fileList.join('\n')
+  const x64Section = shaEntries.x64.map(formatEntry).join('\n');
+  const armSection = shaEntries.arm.map(formatEntry).join('\n');
+  const arm64Section = shaEntries.arm64.map(formatEntry).join('\n');
 
   const draftReleaseNotes = `${changelogText}
 
-## SHA-256 hashes:
+## SHA-256 checksums:
 
-${fileListText}`
+### x64
+
+${x64Section}
+
+### ARM64
+
+${arm64Section}
+
+### ARM
+
+${armSection}`
 
   return draftReleaseNotes
 }

--- a/script/generate-release-notes.ts
+++ b/script/generate-release-notes.ts
@@ -16,6 +16,21 @@ const Glob = glob.GlobSync
 const args = process.argv.slice(2)
 const artifactsDir = args[0]
 
+if (!artifactsDir) {
+  console.error(
+    `🔴 First parameter with artifacts directory not found. Aborting...`
+  )
+  process.exit(1)
+}
+
+const releaseTagWithoutPrefix = args[1]
+if (!releaseTagWithoutPrefix) {
+  console.error(`🔴 Second parameter with release tag not found. Aborting...`)
+  process.exit(1)
+}
+
+console.log(`Preparing release notes for release tag ${releaseTagWithoutPrefix}`)
+
 const files = new Glob(artifactsDir + '/**/*', { nodir: true })
 
 let countFiles = 0

--- a/script/generate-release-notes.ts
+++ b/script/generate-release-notes.ts
@@ -1,6 +1,6 @@
-import * as glob from 'glob'
-import { basename } from 'path'
-import * as fs from 'fs'
+const glob = require('glob')
+const { basename } = require('path')
+const fs = require('fs')
 
 // eslint-disable-next-line no-sync
 const Glob = glob.GlobSync

--- a/script/package.ts
+++ b/script/package.ts
@@ -182,6 +182,9 @@ async function generateChecksums(files: Array<string>) {
   for (const [fullPath, checksum] of checksums) {
     const fileName = path.basename(fullPath)
     checksumsText += `${checksum} - ${fileName}\n`
+
+    const checksumFilePath = `${fullPath}.sha256`
+    await writeFile(checksumFilePath, checksum)
   }
 
   const checksumFile = path.join(distRoot, 'checksums.txt')


### PR DESCRIPTION
 - [x] can see `pubish` job runs after all builds complete
 - [x] see artifacts directory with all files
 - [x] can see `script/generate-release-notes.ts` run and contain checksums
 - [x] get version from tag and pass to draft release
 - [x] generate draft release body using checksums
