### PR TITLE
add support for generating release notes from upstream release

### DIFF
--- a/script/generate-release-notes.ts
+++ b/script/generate-release-notes.ts
@@ -8,10 +8,15 @@ type ChecksumEntry = { filename: string; checksum: string }
 
 type ChecksumGroups = Record<'x64' | 'arm' | 'arm64', Array<ChecksumEntry>>
 
-type ReleaseNotesGroups = Record<
-  'new' | 'added' | 'fixed' | 'improved' | 'removed',
-  Array<string>
->
+type ReleaseNotesGroupType = 'new' | 'added' | 'fixed' | 'improved' | 'removed'
+
+type ReleaseNotesGroups = Record<ReleaseNotesGroupType, Array<ReleaseNoteEntry>>
+
+type ReleaseNoteEntry = {
+  text: string
+  ids: Array<number>
+  contributor?: string
+}
 
 // 3 architectures * 3 package formats * 2 files (package + checksum file)
 const SUCCESSFUL_RELEASE_FILE_COUNT = 3 * 3 * 2
@@ -123,6 +128,20 @@ function extractIds(str: string): Array<number> {
   return idArray
 }
 
+function parseCategory(str: string): ReleaseNotesGroupType | null {
+  const input = str.toLocaleLowerCase()
+  switch (input) {
+    case 'added':
+    case 'fixed':
+    case 'improved':
+    case 'new':
+    case 'removed':
+      return input
+    default:
+      return null
+  }
+}
+
 function getReleaseGroups(version: string): ReleaseNotesGroups {
   if (!version.endsWith('-linux1')) {
     return {
@@ -149,7 +168,7 @@ function getReleaseGroups(version: string): ReleaseNotesGroups {
     process.exit(1)
   }
 
-  console.log(`got release notes`, changelogForVersion)
+  console.log(`found release notes`, changelogForVersion)
 
   const releaseNotesByGroup: ReleaseNotesGroups = {
     new: [],
@@ -163,24 +182,38 @@ function getReleaseGroups(version: string): ReleaseNotesGroups {
   const releaseEntryRegex = /\[(.*)\](.*)- (.*)/
 
   for (const entry of changelogForVersion) {
-    console.log(`parsing entry: '${entry}'`)
-
     const externalMatch = releaseEntryExternalContributor.exec(entry)
     if (externalMatch) {
-      const category = externalMatch[1]
+      const category = parseCategory(externalMatch[1])
       const text = externalMatch[2].trim()
       const ids = extractIds(externalMatch[3])
-      const author = externalMatch[4]
-      console.log(`got match`, { category, text, ids, author })
+      const contributor = externalMatch[4]
+
+      if (!category) {
+        console.warn(`unable to identify category for '${entry}'`)
+      } else {
+        releaseNotesByGroup[category].push({
+          text,
+          ids,
+          contributor,
+        })
+      }
     } else {
       const match = releaseEntryRegex.exec(entry)
       if (match) {
-        const category = match[1]
+        const category = parseCategory(match[1])
         const text = match[2].trim()
         const ids = extractIds(match[3])
-        console.log(`got match`, { category, text, ids })
+        if (!category) {
+          console.warn(`unable to identify category for '${entry}'`)
+        } else {
+          releaseNotesByGroup[category].push({
+            text,
+            ids,
+          })
+        }
       } else {
-        console.warn(`release entry does not match format: '${entry}'`)
+        console.warn(`release entry does not match any format: '${entry}'`)
       }
     }
   }
@@ -188,13 +221,22 @@ function getReleaseGroups(version: string): ReleaseNotesGroups {
   return releaseNotesByGroup
 }
 
-function formatReleaseNote(note: string): string {
-  return ` - ${note}`
+function formatReleaseNote(note: ReleaseNoteEntry): string {
+  const idsAsUrls = note.ids
+    .map(id => `https://github.com/desktop/desktop/issues/${id}`)
+    .join(' ')
+  const contributorNote = note.contributor
+    ? `. Thanks ${note.contributor}!`
+    : ''
+
+  const template = ` - ${note.text} - ${idsAsUrls}${contributorNote}`
+
+  return template.trim()
 }
 
 function renderSection(
   name: string,
-  items: Array<string>,
+  items: Array<ReleaseNoteEntry>,
   omitIfEmpty: boolean = true
 ): string {
   if (items.length === 0 && omitIfEmpty) {
@@ -230,7 +272,6 @@ function renderArchitectureIfNotEmpty(
 ## ${name}
 
 ${itemsText}
-  
   `
 }
 

--- a/script/generate-release-notes.ts
+++ b/script/generate-release-notes.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-sync */
 
 const glob = require('glob')
-const { basename } = require('path')
+const { basename, dirname, join } = require('path')
 const fs = require('fs')
 
 type ChecksumEntry = { filename: string; checksum: string }
@@ -76,23 +76,16 @@ const shaEntriesByArchitecture: ChecksumGroups = {
   ),
 }
 
-// TODO: populate these from changelog if version matches convention
-const releaseNotesByGroup: ReleaseNotesGroups = {
-  new: [],
-  added: [],
-  fixed: [],
-  improved: [],
-  removed: [],
-}
-
 console.log(`Found ${countFiles} files in artifacts directory`)
 console.log(shaEntriesByArchitecture)
+
+const releaseNotesByGroup = getReleaseGroups(releaseTagWithoutPrefix)
 
 const draftReleaseNotes = generateDraftReleaseNotes(
   releaseNotesByGroup,
   shaEntriesByArchitecture
 )
-const releaseNotesPath = __dirname + '/release_notes.txt'
+const releaseNotesPath = join(__dirname, 'release_notes.txt')
 
 fs.writeFileSync(releaseNotesPath, draftReleaseNotes, { encoding: 'utf8' })
 
@@ -111,6 +104,88 @@ function getShaContents(filePath: string): {
   const checksum = fs.readFileSync(filePath, 'utf8')
 
   return { filename, checksum }
+}
+
+function extractIds(str: string): Array<number> {
+  const idRegex = /#(\d+)/g
+
+  const idArray = new Array<number>()
+  let match
+
+  while ((match = idRegex.exec(str))) {
+    const textValue = match[1].trim()
+    const numValue = parseInt(textValue, 10)
+    if (!isNaN(numValue)) {
+      idArray.push(numValue)
+    }
+  }
+
+  return idArray
+}
+
+function getReleaseGroups(version: string): ReleaseNotesGroups {
+  if (!version.endsWith('-linux1')) {
+    return {
+      new: [],
+      added: [],
+      fixed: [],
+      improved: [],
+      removed: [],
+    }
+  }
+
+  const upstreamVersion = version.replace('-linux1', '')
+  const rootDir = dirname(__dirname)
+  const changelogFile = fs.readFileSync(join(rootDir, 'changelog.json'))
+  const changelogJson = JSON.parse(changelogFile)
+  const releases = changelogJson['releases']
+  const changelogForVersion: Array<string> | undefined =
+    releases[upstreamVersion]
+
+  if (!changelogForVersion) {
+    console.error(
+      `🔴 Changelog version ${upstreamVersion} not found in changelog.json, which is required for publishing a release based off an upstream releease. Aborting...`
+    )
+    process.exit(1)
+  }
+
+  console.log(`got release notes`, changelogForVersion)
+
+  const releaseNotesByGroup: ReleaseNotesGroups = {
+    new: [],
+    added: [],
+    fixed: [],
+    improved: [],
+    removed: [],
+  }
+
+  const releaseEntryExternalContributor = /\[(.*)\](.*)- (.*)\. Thanks (.*)!/
+  const releaseEntryRegex = /\[(.*)\](.*)- (.*)/
+
+  for (const entry of changelogForVersion) {
+    console.log(`parsing entry: '${entry}'`)
+
+    const externalMatch = releaseEntryExternalContributor.exec(entry)
+    if (externalMatch) {
+      const category = externalMatch[1]
+      const text = externalMatch[2].trim()
+      const ids = extractIds(externalMatch[3])
+      const author = externalMatch[4]
+      console.log(`got match`, { category, text, ids, author })
+    } else {
+      const match = releaseEntryRegex.exec(entry)
+      if (match) {
+        const category = match[1]
+        const text = match[2].trim()
+        const ids = extractIds(match[3])
+        console.log(`got match`, { category, text, ids })
+      } else {
+        console.warn(`release entry does not match format: '${entry}'`)
+      }
+    }
+  }
+
+  return releaseNotesByGroup
 }
 
 function formatReleaseNote(note: string): string {

--- a/script/generate-release-notes.ts
+++ b/script/generate-release-notes.ts
@@ -8,6 +8,11 @@ type ChecksumEntry = { filename: string; checksum: string }
 
 type ChecksumGroups = Record<'x64' | 'arm' | 'arm64', Array<ChecksumEntry>>
 
+type ReleaseNotesGroups = Record<
+  'new' | 'added' | 'fixed' | 'improved' | 'removed',
+  Array<string>
+>
+
 // 3 architectures * 3 package formats * 2 files (package + checksum file)
 const SUCCESSFUL_RELEASE_FILE_COUNT = 3 * 3 * 2
 
@@ -71,11 +76,20 @@ const shaEntriesByArchitecture: ChecksumGroups = {
   ),
 }
 
+// TODO: populate these from changelog if version matches convention
+const releaseNotesByGroup: ReleaseNotesGroups = {
+  new: [],
+  added: [],
+  fixed: [],
+  improved: [],
+  removed: [],
+}
+
 console.log(`Found ${countFiles} files in artifacts directory`)
 console.log(shaEntriesByArchitecture)
 
 const draftReleaseNotes = generateDraftReleaseNotes(
-  [],
+  releaseNotesByGroup,
   shaEntriesByArchitecture
 )
 const releaseNotesPath = __dirname + '/release_notes.txt'
@@ -99,42 +113,71 @@ function getShaContents(filePath: string): {
   return { filename, checksum }
 }
 
+function formatReleaseNote(note: string): string {
+  return ` - ${note}`
+}
+
+function renderSection(
+  name: string,
+  items: Array<string>,
+  omitIfEmpty: boolean = true
+): string {
+  if (items.length === 0 && omitIfEmpty) {
+    return ''
+  }
+
+  const itemsText =
+    items.length === 0 ? 'TODO' : items.map(formatReleaseNote).join('\n')
+
+  return `
+## ${name}
+
+${itemsText}
+  `
+}
+
 function formatEntry(e: ChecksumEntry): string {
   return `**${e.filename}**\n${e.checksum}\n`
+}
+
+function renderArchitectureIfNotEmpty(
+  name: string,
+  items: Array<ChecksumEntry>
+): string {
+  if (items.length === 0) {
+    return ''
+  }
+
+  const itemsText = items.map(formatEntry).join('\n')
+
+  return `
+  
+## ${name}
+
+${itemsText}
+  
+  `
 }
 
 /**
  * Takes the release notes entries and the SHA entries, then merges them into the full draft release notes ✨
  */
 function generateDraftReleaseNotes(
-  releaseNotesEntries: Array<string>,
+  releaseNotesGroups: ReleaseNotesGroups,
   shaEntries: ChecksumGroups
 ): string {
-  const changelogText = releaseNotesEntries.join('\n')
-
-  const x64Section = shaEntries.x64.map(formatEntry).join('\n')
-  const armSection = shaEntries.arm.map(formatEntry).join('\n')
-  const arm64Section = shaEntries.arm64.map(formatEntry).join('\n')
-
-  const draftReleaseNotes = `${changelogText}
-
-## Fixes and improvements
-
-TODO
+  const draftReleaseNotes = `
+${renderSection('New', releaseNotesGroups.new)}
+${renderSection('Added', releaseNotesGroups.added)}
+${renderSection('Fixed', releaseNotesGroups.fixed, false)}
+${renderSection('Improved', releaseNotesGroups.improved, false)}
+${renderSection('Removed', releaseNotesGroups.removed)}
 
 ## SHA-256 checksums
 
-### x64
-
-${x64Section}
-
-### ARM64
-
-${arm64Section}
-
-### ARM
-
-${armSection}`
+${renderArchitectureIfNotEmpty('x64', shaEntries.x64)}
+${renderArchitectureIfNotEmpty('ARM64', shaEntries.arm64)}
+${renderArchitectureIfNotEmpty('ARM', shaEntries.arm)}`
 
   return draftReleaseNotes
 }


### PR DESCRIPTION
This PR adds support to the `script/generate-release-notes` tool to read the `changelog.json` entries where a version represents the first release based on the given upstream release, and generates the release body matching the template that we use currently, with a couple of tweaks:

 - `Fixes` and `Improvements` now get their own sections
 - SHA256 checksums section format changed (to support organizing by architecture)