### PR TITLE
Add an option to use the Windows title bar

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -32,6 +32,7 @@ import { WindowState } from './window-state'
 import { Shell } from './shells'
 
 import { ApplicableTheme, ApplicationTheme } from '../ui/lib/application-theme'
+import { TitleBarStyle } from '../ui/lib/title-bar-style'
 import { IAccountRepositories } from './stores/api-repositories-store'
 import { ManualConflictResolution } from '../models/manual-conflict-resolution'
 import { Banner } from '../models/banner'
@@ -274,6 +275,9 @@ export interface IAppState {
 
   /** The currently applied appearance (aka theme) */
   readonly currentTheme: ApplicableTheme
+
+  /** The selected title bar style for the application */
+  readonly titleBarStyle: TitleBarStyle
 
   /**
    * A map keyed on a user account (GitHub.com or GitHub Enterprise)

--- a/app/src/lib/get-title-bar-config.ts
+++ b/app/src/lib/get-title-bar-config.ts
@@ -1,0 +1,48 @@
+import { writeFile } from 'fs/promises'
+import { existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { app } from 'electron'
+import { TitleBarStyle } from '../ui/lib/title-bar-style'
+
+export type TitleBarConfig = {
+  titleBarStyle: TitleBarStyle
+}
+
+let cachedTitleBarConfig: TitleBarConfig | null = null
+
+// The function has to be synchronous,
+// since we need its return value to create electron BrowserWindow
+export function readTitleBarConfigFileSync(): TitleBarConfig {
+  if (cachedTitleBarConfig) {
+    return cachedTitleBarConfig
+  }
+
+  const titleBarConfigPath = getTitleBarConfigPath()
+
+  if (existsSync(titleBarConfigPath)) {
+    const storedTitleBarConfig = JSON.parse(
+      readFileSync(titleBarConfigPath, 'utf8')
+    )
+
+    if (
+      storedTitleBarConfig.titleBarStyle === 'native' ||
+      storedTitleBarConfig.titleBarStyle === 'custom'
+    ) {
+      cachedTitleBarConfig = storedTitleBarConfig
+    }
+  }
+
+  // Cache the default value if the config file is not found, or if it contains an invalid value.
+  if (cachedTitleBarConfig == null) {
+    cachedTitleBarConfig = { titleBarStyle: 'native' }
+  }
+
+  return cachedTitleBarConfig
+}
+
+export function saveTitleBarConfigFile(config: TitleBarConfig) {
+  return writeFile(getTitleBarConfigPath(), JSON.stringify(config), 'utf8')
+}
+
+const getTitleBarConfigPath = () =>
+  join(app.getPath('userData'), '.title-bar-config')

--- a/app/src/lib/ipc-shared.ts
+++ b/app/src/lib/ipc-shared.ts
@@ -13,6 +13,7 @@ import { Architecture } from './get-architecture'
 import { EndpointToken } from './endpoint-token'
 import { PathType } from '../ui/lib/app-proxy'
 import { ThemeSource } from '../ui/lib/theme-source'
+import { TitleBarStyle } from '../ui/lib/title-bar-style'
 import { DesktopNotificationPermission } from 'desktop-notifications/dist/notification-permission'
 import { NotificationCallback } from 'desktop-notifications/dist/notification-callback'
 import { DesktopAliveEvent } from './stores/alive-store'
@@ -65,6 +66,7 @@ export type RequestChannels = {
   blur: () => void
   'update-accounts': (accounts: ReadonlyArray<EndpointToken>) => void
   'quit-and-install-updates': () => void
+  'restart-app': () => void
   'quit-app': () => void
   'minimize-window': () => void
   'maximize-window': () => void
@@ -121,6 +123,8 @@ export type RequestResponseChannels = {
   'should-use-dark-colors': () => Promise<boolean>
   'save-guid': (guid: string) => Promise<void>
   'get-guid': () => Promise<string>
+  'save-title-bar-style': (titleBarStyle: TitleBarStyle) => Promise<void>
+  'get-title-bar-style': () => Promise<TitleBarStyle>
   'show-notification': (
     title: string,
     body: string,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -80,6 +80,7 @@ import {
   getPersistedThemeName,
   setPersistedTheme,
 } from '../../ui/lib/application-theme'
+import { TitleBarStyle } from '../../ui/lib/title-bar-style'
 import {
   getAppMenu,
   getCurrentWindowState,
@@ -91,6 +92,8 @@ import {
   sendWillQuitEvenIfUpdatingSync,
   quitApp,
   sendCancelQuittingSync,
+  saveTitleBarStyle,
+  getTitleBarStyle,
 } from '../../ui/main-process-proxy'
 import {
   API,
@@ -511,6 +514,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private selectedBranchesTab = BranchesTab.Branches
   private selectedTheme = ApplicationTheme.System
   private currentTheme: ApplicableTheme = ApplicationTheme.Light
+  private titleBarStyle: TitleBarStyle = 'native'
 
   private useWindowsOpenSSH: boolean = false
 
@@ -992,6 +996,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       selectedBranchesTab: this.selectedBranchesTab,
       selectedTheme: this.selectedTheme,
       currentTheme: this.currentTheme,
+      titleBarStyle: this.titleBarStyle,
       apiRepositories: this.apiRepositoriesStore.getState(),
       useWindowsOpenSSH: this.useWindowsOpenSSH,
       optOutOfUsageTracking: this.statsStore.getOptOut(),
@@ -2169,6 +2174,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
       this.currentTheme = theme
       this.emitUpdate()
     })
+
+    this.titleBarStyle = await getTitleBarStyle()
 
     this.lastThankYou = getObject<ILastThankYou>(lastThankYouKey)
 
@@ -6459,6 +6466,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.emitUpdate()
 
     return Promise.resolve()
+  }
+
+  /**
+   * Set the title bar style for the application
+   */
+  public _setTitleBarStyle(titleBarStyle: TitleBarStyle) {
+    this.titleBarStyle = titleBarStyle
+    return saveTitleBarStyle(titleBarStyle)
   }
 
   public async _resolveCurrentEditor() {

--- a/app/src/main-process/app-window.ts
+++ b/app/src/main-process/app-window.ts
@@ -13,6 +13,7 @@ import {
   getWindowState,
   registerWindowStateChangedEvents,
 } from '../lib/window-state'
+import { readTitleBarConfigFileSync } from '../lib/get-title-bar-config'
 import { MenuEvent } from './menu'
 import { URLActionType } from '../lib/parse-app-url'
 import { ILaunchStats } from '../lib/stats'
@@ -75,6 +76,9 @@ export class AppWindow {
     } else if (__WIN32__) {
       windowOptions.frame = false
     } else if (__LINUX__) {
+      if (readTitleBarConfigFileSync().titleBarStyle === 'custom') {
+        windowOptions.frame = false
+      }
       windowOptions.icon = join(__dirname, 'static', 'logos', '512x512.png')
 
       // relax restriction here for users trying to run app at a small

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -41,6 +41,10 @@ import {
 import { buildSpellCheckMenu } from './menu/build-spell-check-menu'
 import { getMainGUID, saveGUIDFile } from '../lib/get-main-guid'
 import {
+  readTitleBarConfigFileSync,
+  saveTitleBarConfigFile,
+} from '../lib/get-title-bar-config'
+import {
   getNotificationsPermission,
   requestNotificationsPermission,
   showNotification,
@@ -505,6 +509,11 @@ app.on('ready', () => {
     mainWindow?.quitAndInstallUpdate()
   )
 
+  ipcMain.on('restart-app', () => {
+    app.relaunch()
+    app.exit()
+  })
+
   ipcMain.on('quit-app', () => app.quit())
 
   ipcMain.on('minimize-window', () => mainWindow?.minimizeWindow())
@@ -684,6 +693,16 @@ app.on('ready', () => {
   ipcMain.handle('get-guid', () => getMainGUID())
 
   ipcMain.handle('save-guid', (_, guid) => saveGUIDFile(guid))
+
+  ipcMain.handle(
+    'get-title-bar-style',
+    async () => readTitleBarConfigFileSync().titleBarStyle
+  )
+
+  ipcMain.handle(
+    'save-title-bar-style',
+    async (_, titleBarStyle) => await saveTitleBarConfigFile({ titleBarStyle })
+  )
 
   ipcMain.handle('show-notification', async (_, title, body, userInfo) =>
     showNotification(title, body, userInfo)

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -95,6 +95,7 @@ export enum PopupType {
   PullRequestComment = 'PullRequestComment',
   UnknownAuthors = 'UnknownAuthors',
   ConfirmRepoRulesBypass = 'ConfirmRepoRulesBypass',
+  ConfirmRestart = 'ConfirmRestart',
 }
 
 interface IBasePopup {
@@ -422,5 +423,6 @@ export type PopupDetail =
       branch: string
       onConfirm: () => void
     }
+  | { type: PopupType.ConfirmRestart }
 
 export type Popup = IBasePopup & PopupDetail

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -64,6 +64,7 @@ import { Welcome } from './welcome'
 import { AppMenuBar } from './app-menu'
 import { UpdateAvailable, renderBanner } from './banners'
 import { Preferences } from './preferences'
+import { ConfirmRestart } from './preferences/confirm-restart'
 import { RepositorySettings } from './repository-settings'
 import { AppError } from './app-error'
 import { MissingRepository } from './missing-repository'
@@ -1364,8 +1365,8 @@ export class App extends React.Component<IAppProps, IAppState> {
    * on Windows.
    */
   private renderAppMenuBar() {
-    // We only render the app menu bar on Windows
-    if (!__WIN32__) {
+    // We do not render the app menu bar on macOS
+    if (__DARWIN__) {
       return null
     }
 
@@ -1416,9 +1417,9 @@ export class App extends React.Component<IAppProps, IAppState> {
       this.state.currentFoldout &&
       this.state.currentFoldout.type === FoldoutType.AppMenu
 
-    // As Linux still uses the classic Electron menu, we are opting out of the
-    // custom menu that is shown as part of the title bar below
-    if (__LINUX__) {
+    // We do not render the app menu bar on Linux when the user has selected
+    // the "native" menu option
+    if (__LINUX__ && this.state.titleBarStyle === 'native') {
       return null
     }
 
@@ -1426,12 +1427,12 @@ export class App extends React.Component<IAppProps, IAppState> {
     // the title bar when the menu bar is active. On other platforms we
     // never render the title bar while in full-screen mode.
     if (inFullScreen) {
-      if (!__WIN32__ || !menuBarActive) {
+      if (__DARWIN__ || !menuBarActive) {
         return null
       }
     }
 
-    const showAppIcon = __WIN32__ && !this.state.showWelcomeFlow
+    const showAppIcon = !__DARWIN__ && !this.state.showWelcomeFlow
     const inWelcomeFlow = this.state.showWelcomeFlow
     const inNoRepositoriesView = this.inNoRepositoriesViewState()
 
@@ -1623,6 +1624,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             onDismissed={onPopupDismissedFn}
             selectedShell={this.state.selectedShell}
             selectedTheme={this.state.selectedTheme}
+            titleBarStyle={this.state.titleBarStyle}
             repositoryIndicatorsEnabled={this.state.repositoryIndicatorsEnabled}
           />
         )
@@ -2519,6 +2521,10 @@ export class App extends React.Component<IAppProps, IAppState> {
             onDismissed={onPopupDismissedFn}
           />
         )
+      }
+
+      case PopupType.ConfirmRestart: {
+        return <ConfirmRestart onDismissed={onPopupDismissedFn} />
       }
       default:
         return assertNever(popup, `Unknown popup type: ${popup}`)

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -91,6 +91,7 @@ import { TipState, IValidBranch } from '../../models/tip'
 import { Banner, BannerType } from '../../models/banner'
 
 import { ApplicationTheme } from '../lib/application-theme'
+import { TitleBarStyle } from '../lib/title-bar-style'
 import { installCLI } from '../lib/install-cli'
 import {
   executeMenuItem,
@@ -2473,6 +2474,14 @@ export class Dispatcher {
    */
   public setSelectedTheme(theme: ApplicationTheme) {
     return this.appStore._setSelectedTheme(theme)
+  }
+
+  /**
+   * Set the title bar style for the application
+   */
+  public async setTitleBarStyle(titleBarStyle: TitleBarStyle) {
+    await this.appStore._setTitleBarStyle(titleBarStyle)
+    this.showPopup({ type: PopupType.ConfirmRestart })
   }
 
   /**

--- a/app/src/ui/lib/title-bar-style.ts
+++ b/app/src/ui/lib/title-bar-style.ts
@@ -1,0 +1,17 @@
+/**
+ * This string enum represents the supported modes for rendering the title bar
+ * in the app.
+ *
+ *  - 'native' - Use the default window style and chrome supported by the window
+ *               manager
+ *
+ *  - 'custom' - Hide the default window style and chrome and display the menu
+ *               provided by GitHub Desktop
+ *
+ * This is only available on the Linux build. For other operating systems this
+ * is not configurable:
+ *
+ *  - macOS uses the native title bar
+ *  - Windows uses the custom title bar
+ */
+export type TitleBarStyle = 'native' | 'custom'

--- a/app/src/ui/main-process-proxy.ts
+++ b/app/src/ui/main-process-proxy.ts
@@ -164,6 +164,9 @@ export const checkForUpdates = invokeProxy('check-for-updates', 1)
 /** Tell the main process to quit the app and install updates */
 export const quitAndInstallUpdate = sendProxy('quit-and-install-updates', 0)
 
+/** Tell the main process to restart the app */
+export const restartApp = sendProxy('restart-app', 0)
+
 /** Tell the main process to quit the app */
 export const quitApp = sendProxy('quit-app', 0)
 
@@ -378,6 +381,10 @@ export const showOpenDialog = invokeProxy('show-open-dialog', 1)
 /** Tell the main process read/save the user GUID from/to file */
 export const saveGUID = invokeProxy('save-guid', 1)
 export const getGUID = invokeProxy('get-guid', 0)
+
+/** Tell the main process read/save the the title bar style */
+export const saveTitleBarStyle = invokeProxy('save-title-bar-style', 1)
+export const getTitleBarStyle = invokeProxy('get-title-bar-style', 0)
 
 /** Tell the main process to show a notification */
 export const showNotification = invokeProxy('show-notification', 3)

--- a/app/src/ui/preferences/confirm-restart.tsx
+++ b/app/src/ui/preferences/confirm-restart.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  OkCancelButtonGroup,
+} from '../dialog'
+import { restartApp } from '../main-process-proxy'
+
+interface IConfirmRestartProps {
+  /**
+   * Callback to use when the dialog gets closed.
+   */
+  readonly onDismissed: () => void
+}
+
+export class ConfirmRestart extends React.Component<IConfirmRestartProps> {
+  public constructor(props: IConfirmRestartProps) {
+    super(props)
+  }
+
+  public render() {
+    return (
+      <Dialog
+        dismissable={false}
+        onDismissed={this.props.onDismissed}
+        onSubmit={this.onSubmit}
+        type="warning"
+      >
+        <DialogContent>
+          <p>Restart GitHub Desktop to apply the title bar settings change?</p>
+        </DialogContent>
+        {this.renderFooter()}
+      </Dialog>
+    )
+  }
+
+  private renderFooter() {
+    return (
+      <DialogFooter>
+        <OkCancelButtonGroup
+          okButtonText="Restart"
+          cancelButtonText="Not Now"
+          onCancelButtonClick={this.onNotNow}
+        />
+      </DialogFooter>
+    )
+  }
+
+  private onNotNow = () => {
+    this.props.onDismissed()
+  }
+
+  private onSubmit = async () => {
+    this.props.onDismissed()
+    restartApp()
+  }
+}

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -21,6 +21,7 @@ import {
 } from '../lib/identifier-rules'
 import { Appearance } from './appearance'
 import { ApplicationTheme } from '../lib/application-theme'
+import { TitleBarStyle } from '../lib/title-bar-style'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { Integrations } from './integrations'
 import {
@@ -63,6 +64,7 @@ interface IPreferencesProps {
   readonly selectedExternalEditor: string | null
   readonly selectedShell: Shell
   readonly selectedTheme: ApplicationTheme
+  readonly titleBarStyle: TitleBarStyle
   readonly repositoryIndicatorsEnabled: boolean
 }
 
@@ -90,6 +92,7 @@ interface IPreferencesState {
   readonly selectedExternalEditor: string | null
   readonly availableShells: ReadonlyArray<Shell>
   readonly selectedShell: Shell
+  readonly titleBarStyle: TitleBarStyle
   /**
    * If unable to save Git configuration values (name, email)
    * due to an existing configuration lock file this property
@@ -137,6 +140,7 @@ export class Preferences extends React.Component<
       selectedExternalEditor: this.props.selectedExternalEditor,
       availableShells: [],
       selectedShell: this.props.selectedShell,
+      titleBarStyle: this.props.titleBarStyle,
       repositoryIndicatorsEnabled: this.props.repositoryIndicatorsEnabled,
       initiallySelectedTheme: this.props.selectedTheme,
       isLoadingGitConfig: true,
@@ -348,6 +352,8 @@ export class Preferences extends React.Component<
           <Appearance
             selectedTheme={this.props.selectedTheme}
             onSelectedThemeChanged={this.onSelectedThemeChanged}
+            titleBarStyle={this.props.titleBarStyle}
+            onTitleBarStyleChanged={this.onTitleBarStyleChanged}
           />
         )
         break
@@ -501,6 +507,10 @@ export class Preferences extends React.Component<
     this.props.dispatcher.setSelectedTheme(theme)
   }
 
+  private onTitleBarStyleChanged = (titleBarStyle: TitleBarStyle) => {
+    this.setState({ titleBarStyle })
+  }
+
   private renderFooter() {
     const hasDisabledError = this.state.disallowedCharactersMessage != null
 
@@ -607,6 +617,7 @@ export class Preferences extends React.Component<
       )
     }
     await this.props.dispatcher.setShell(this.state.selectedShell)
+    await this.props.dispatcher.setTitleBarStyle(this.state.titleBarStyle)
     await this.props.dispatcher.setConfirmDiscardChangesSetting(
       this.state.confirmDiscardChanges
     )

--- a/app/src/ui/window/title-bar.tsx
+++ b/app/src/ui/window/title-bar.tsx
@@ -84,7 +84,7 @@ export class TitleBar extends React.Component<ITitleBarProps> {
     const isMaximized = this.props.windowState === 'maximized'
 
     // No Windows controls when we're in full-screen mode.
-    const winControls = __WIN32__ && !inFullScreen ? <WindowControls /> : null
+    const winControls = !inFullScreen ? <WindowControls /> : null
 
     // On Windows it's not possible to resize a frameless window if the
     // element that sits flush along the window edge has -webkit-app-region: drag.
@@ -92,12 +92,14 @@ export class TitleBar extends React.Component<ITitleBarProps> {
     // window controls need to disable dragging so we add a 3px tall element which
     // disables drag while still letting users drag the app by the titlebar below
     // those 3px.
-    const topResizeHandle =
-      __WIN32__ && !isMaximized ? <div className="resize-handle top" /> : null
+    const topResizeHandle = !isMaximized ? (
+      <div className="resize-handle top" />
+    ) : null
 
     // And a 3px wide element on the left hand side.
-    const leftResizeHandle =
-      __WIN32__ && !isMaximized ? <div className="resize-handle left" /> : null
+    const leftResizeHandle = !isMaximized ? (
+      <div className="resize-handle left" />
+    ) : null
 
     const titleBarClass =
       this.props.titleBarStyle === 'light' ? 'light-title-bar' : ''

--- a/app/src/ui/window/window-controls.tsx
+++ b/app/src/ui/window/window-controls.tsx
@@ -112,11 +112,6 @@ export class WindowControls extends React.Component<{}, IWindowControlState> {
   }
 
   public render() {
-    // We only know how to render fake Windows-y controls
-    if (!__WIN32__) {
-      return <span />
-    }
-
     const min = this.renderButton('minimize', this.onMinimize, minimizePath)
     const maximizeOrRestore =
       this.state.windowState === 'maximized'

--- a/app/styles/ui/window/_title-bar.scss
+++ b/app/styles/ui/window/_title-bar.scss
@@ -15,7 +15,7 @@
     border-bottom: 1px solid #000;
   }
 
-  @include win32 {
+  @mixin custom-title-bar {
     height: var(--win32-title-bar-height);
     background: var(--win32-title-bar-background-color);
     border-bottom: 1px solid #000;
@@ -25,6 +25,14 @@
       margin: 0 var(--spacing);
       align-self: center;
     }
+  }
+
+  @include win32 {
+    @include custom-title-bar;
+  }
+
+  @include linux {
+    @include custom-title-bar;
   }
 
   .resize-handle {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #285

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
This pull request add an option to the preference dialog for enabling the Windows title bar.

Since restarting electron is required for changes to take effect, a dialog will be shown asking if user wanted to restart right away.

The two options, "custom" and "native" comes from the similar option in VS Code, so they should familiar enough for most users.

![image](https://github.com/shiftkey/desktop/assets/91261297/bed5afb2-34e3-45df-a877-e113a04032eb)

TODO:

- [x] Fix comments
- [x] Sort imports
- [x] Rebase changes to a single commit

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

![](https://github.com/shiftkey/desktop/assets/91261297/27e3fd0b-7b4c-449a-9428-2defd5dde88b)

![](https://github.com/shiftkey/desktop/assets/91261297/0117384e-d44e-493d-8125-601702fd3b46)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
