### PR TITLE
bump included runner to macOS 13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,10 @@ jobs:
       fail-fast: false
       matrix:
         node: [18.16.1]
-        os: [macos-11, windows-2019, ubuntu-20.04]
+        os: [macos-13, windows-2019, ubuntu-20.04]
         arch: [x64, arm64]
         include:
-          - os: macos-11
+          - os: macos-13
             friendlyName: macOS
           - os: windows-2019
             friendlyName: Windows


### PR DESCRIPTION
The upstream project has been testing macOS 13 for their CI, and we should also use this version to test our changes.
