### PR TITLE
skip newer python installation to get ubuntu runners working on latest release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,7 @@ jobs:
           ref: ${{ inputs.ref }}
           submodules: recursive
       - uses: actions/setup-python@v4
+        if: matrix.friendlyName != 'Ubuntu'
         with:
           python-version: '3.11'
       - name: Use Node.js ${{ matrix.node }}


### PR DESCRIPTION
Getting the toolchain running again after rebasing on top of the latest `development` commits