### PR TITLE
update @types/node to later version to try and sync with upstream changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "@types/legal-eagle": "^0.15.0",
     "@types/memoize-one": "^3.1.1",
     "@types/mri": "^1.1.0",
-    "@types/node": "18.16.1",
+    "@types/node": "18.16.20",
     "@types/prettier": "^2.0.1",
     "@types/react": "^16.8.7",
     "@types/react-css-transition-replace": "^2.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1463,10 +1463,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.24.tgz#d4606afd8cf6c609036b854360367d1b2c78931f"
   integrity sha512-1Ciqv9pqwVtW6FsIUKSZNB82E5Cu1I2bBTj1xuIHXLe/1zYLl3956Nbhg2MzSYHVfl9/rmanjbQIb7LibfCnug==
 
-"@types/node@18.16.1":
-  version "18.16.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.1.tgz#5db121e9c5352925bb1f1b892c4ae620e3526799"
-  integrity sha512-DZxSZWXxFfOlx7k7Rv4LAyiMroaxa3Ly/7OOzZO8cBNho0YzAi4qlbrx8W27JGqG57IgR/6J7r+nOJWw6kcvZA==
+"@types/node@18.16.20":
+  version "18.16.20"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.20.tgz#b27be1ceb267bfb47d8bac024ff6379998f62207"
+  integrity sha512-nL54VfDjThdP2UXJXZao5wp76CDiDw4zSRO8d4Tk7UgDqNKGKVEQB0/t3ti63NS+YNNkIQDvwEAF04BO+WYu7Q==
 
 "@types/node@^18.11.18":
   version "18.16.3"


### PR DESCRIPTION
This package upgrade seems to break a bunch of `armv7l` references in the typechecker so I'm going to try and pull in a later version to hopefully assist with rebasing...