### PR TITLE
Add Pluma support for Linux external editor options

### DIFF
--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -174,6 +174,10 @@ const editors: ILinuxExternalEditor[] = [
     name: 'Pulsar',
     paths: ['/usr/bin/pulsar'],
   },
+  {
+    name: 'Pluma',
+    paths: ['/usr/bin/pluma'],
+  },
 ]
 
 async function getAvailablePath(paths: string[]): Promise<string | null> {

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -357,6 +357,7 @@ These editors are currently supported:
  - [JetBrains Goland](https://www.jetbrains.com/go/)
  - [Emacs](https://www.gnu.org/software/emacs/)
  - [Pulsar](https://pulsar-edit.dev/)
+ - [Pluma](https://github.com/mate-desktop/pluma)
 
 These are defined in a list at the top of the file:
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

This does not address an open issue.

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
This editor satisfies all the criteria required for it to be integrated. 
- Pluma supports opening directories.
- Pluma is user-installable.
- Pluma can open files and directories via the command line.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
