### PR TITLE
Use Ctrl+Q to quit

### DIFF
--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -135,7 +135,7 @@ export function buildDefaultMenu({
       {
         role: 'quit',
         label: 'E&xit',
-        accelerator: 'Alt+F4',
+        accelerator: 'CmdOrCtrl+Q',
       }
     )
   }


### PR DESCRIPTION
Closes #484

## Description

Ctrl+Q is a standard shortcut across Linux apps.

## Release notes

Notes:
Change the keyboard shortcut for quitting the app to Ctrl+Q