### PR TITLE
update Electron to 26.6.8

### DIFF
--- a/app/.npmrc
+++ b/app/.npmrc
@@ -1,3 +1,3 @@
 runtime = electron
 disturl = https://electronjs.org/headers
-target = 26.6.1
+target = 26.6.8

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "@types/webpack-hot-middleware": "^2.25.6",
     "@types/webpack-merge": "^5.0.0",
     "@types/xml2js": "^0.4.11",
-    "electron": "26.6.1",
+    "electron": "26.6.8",
     "electron-builder": "^24.9.1",
     "electron-packager": "^17.1.2",
     "eslint-plugin-github": "^4.10.1",

--- a/script/validate-electron-version.ts
+++ b/script/validate-electron-version.ts
@@ -15,8 +15,8 @@ type ChannelToValidate = 'production' | 'beta'
  * to a previous version of GitHub Desktop without losing all settings.
  */
 const ValidElectronVersions: Record<ChannelToValidate, string> = {
-  production: '26.6.1',
-  beta: '26.6.1',
+  production: '26.6.8',
+  beta: '26.6.8',
 }
 
 const channel =

--- a/yarn.lock
+++ b/yarn.lock
@@ -3991,10 +3991,10 @@ electron-winstaller@*, electron-winstaller@^5.0.0:
     lodash.template "^4.2.2"
     temp "^0.9.0"
 
-electron@26.6.1:
-  version "26.6.1"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-26.6.1.tgz#bf4835d92210ccbec632088d1975bf78ed05c153"
-  integrity sha512-4Vz9u0Jt/khPa/en2l8Jv6SWEfsK/ieWYtchl5j0clbNSjdeTucnEFOhz9B9WwsAmfQjxBnpuMZpmdBuyxq+wg==
+electron@26.6.8:
+  version "26.6.8"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-26.6.8.tgz#c31a4fbd9101bcead4a2ff778638cc501b0c5ed9"
+  integrity sha512-nuzJ5nVButL1jErc97IVb+A6jbContMg5Uuz5fhmZ4NLcygLkSW8FZpnOT7A4k8Saa95xDJOvqGZyQdI/OPNFw==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^18.11.18"


### PR DESCRIPTION
https://releases.electronjs.org/releases/stable?version=26&limit=8

Changelog mostly looks like security backports