### PR TITLE
Add support for Pycharm Professional from snap

### DIFF
--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -132,6 +132,7 @@ const editors: ILinuxExternalEditor[] = [
     name: 'JetBrains PyCharm',
     paths: [
       '/snap/bin/pycharm',
+      '/snap/bin/pycharm-professional',
       '.local/share/JetBrains/Toolbox/scripts/pycharm',
     ],
   },


### PR DESCRIPTION
Closes #1054

## Description
- Adds support for the Pycharm Professional Snap package to be used as an external editor.

