### PR TITLE
shells: add Black Box terminal

### DIFF
--- a/app/src/lib/shells/linux.ts
+++ b/app/src/lib/shells/linux.ts
@@ -25,6 +25,7 @@ export enum Shell {
   Kitty = 'Kitty',
   LXTerminal = 'LXDE Terminal',
   Warp = 'Warp',
+  BlackBox = 'Black Box',
 }
 
 export const Default = Shell.Gnome
@@ -71,6 +72,8 @@ function getShellPath(shell: Shell): Promise<string | null> {
       return getPathIfAvailable('/usr/bin/lxterminal')
     case Shell.Warp:
       return getPathIfAvailable('/usr/bin/warp-terminal')
+    case Shell.BlackBox:
+      return getPathIfAvailable('/usr/bin/blackbox-terminal')
     default:
       return assertNever(shell, `Unknown shell: ${shell}`)
   }
@@ -96,6 +99,7 @@ export async function getAvailableShells(): Promise<
     kittyPath,
     lxterminalPath,
     warpPath,
+    blackBoxPath,
   ] = await Promise.all([
     getShellPath(Shell.Gnome),
     getShellPath(Shell.GnomeConsole),
@@ -113,6 +117,7 @@ export async function getAvailableShells(): Promise<
     getShellPath(Shell.Kitty),
     getShellPath(Shell.LXTerminal),
     getShellPath(Shell.Warp),
+    getShellPath(Shell.BlackBox),
   ])
 
   const shells: Array<FoundShell<Shell>> = []
@@ -180,6 +185,10 @@ export async function getAvailableShells(): Promise<
     shells.push({ shell: Shell.Warp, path: warpPath })
   }
 
+  if (blackBoxPath) {
+    shells.push({ shell: Shell.BlackBox, path: blackBoxPath })
+  }
+
   return shells
 }
 
@@ -196,6 +205,7 @@ export function launch(
     case Shell.Terminator:
     case Shell.XFCE:
     case Shell.Alacritty:
+    case Shell.BlackBox:
       return spawn(foundShell.path, ['--working-directory', path])
     case Shell.Urxvt:
       return spawn(foundShell.path, ['-cd', path])

--- a/docs/technical/shell-integration.md
+++ b/docs/technical/shell-integration.md
@@ -241,6 +241,7 @@ These shells are currently supported:
  - [Konsole](https://konsole.kde.org/)
  - [XTerm](http://invisible-island.net/xterm/)
  - [Terminology](https://www.enlightenment.org/docs/apps/terminology.md)
+ - [Black Box](https://gitlab.gnome.org/raggesilver/blackbox)
 
 These are defined in an enum at the top of the file:
 
@@ -254,6 +255,7 @@ export enum Shell {
   Konsole = 'Konsole',
   Xterm = 'XTerm',
   Terminology = 'Terminology',
+  BlackBox = 'Black Box',
 }
 ```
 


### PR DESCRIPTION


## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- Adds support for the [Black Box](https://gitlab.gnome.org/raggesilver/blackbox) terminal on Linux.
- The flatpak isn't supported, just the native binary from e.g. Fedora's repos.
- I added Black Box to the list of supported shells in `docs/technical/shell-integration.md` but this list seems out of date or purposefully truncated. Let me know if you want me to undo my addition to the docs

![image](https://github.com/user-attachments/assets/427873d1-cde4-4b51-8de5-056d2e69460d)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: Added support for the Black Box terminal

