### PR TITLE
shells: add Ptyxis terminal

### DIFF
--- a/app/src/lib/shells/linux.ts
+++ b/app/src/lib/shells/linux.ts
@@ -235,7 +235,10 @@ export function launch(
     case Shell.Warp:
       return spawn(foundShell.path, [], { cwd: path })
     case Shell.Ptyxis:
-      return spawn(foundShell.path, ['--new-window', '--working-directory=' + path])
+      return spawn(foundShell.path, [
+        '--new-window',
+        '--working-directory=' + path,
+      ])
     default:
       return assertNever(shell, `Unknown shell: ${shell}`)
   }

--- a/app/src/lib/shells/linux.ts
+++ b/app/src/lib/shells/linux.ts
@@ -26,6 +26,7 @@ export enum Shell {
   LXTerminal = 'LXDE Terminal',
   Warp = 'Warp',
   BlackBox = 'Black Box',
+  Ptyxis = 'Ptyxis',
 }
 
 export const Default = Shell.Gnome
@@ -74,6 +75,8 @@ function getShellPath(shell: Shell): Promise<string | null> {
       return getPathIfAvailable('/usr/bin/warp-terminal')
     case Shell.BlackBox:
       return getPathIfAvailable('/usr/bin/blackbox-terminal')
+    case Shell.Ptyxis:
+      return getPathIfAvailable('/usr/bin/ptyxis')
     default:
       return assertNever(shell, `Unknown shell: ${shell}`)
   }
@@ -100,6 +103,7 @@ export async function getAvailableShells(): Promise<
     lxterminalPath,
     warpPath,
     blackBoxPath,
+    ptyxisPath,
   ] = await Promise.all([
     getShellPath(Shell.Gnome),
     getShellPath(Shell.GnomeConsole),
@@ -118,6 +122,7 @@ export async function getAvailableShells(): Promise<
     getShellPath(Shell.LXTerminal),
     getShellPath(Shell.Warp),
     getShellPath(Shell.BlackBox),
+    getShellPath(Shell.Ptyxis),
   ])
 
   const shells: Array<FoundShell<Shell>> = []
@@ -189,6 +194,10 @@ export async function getAvailableShells(): Promise<
     shells.push({ shell: Shell.BlackBox, path: blackBoxPath })
   }
 
+  if (ptyxisPath) {
+    shells.push({ shell: Shell.Ptyxis, path: ptyxisPath })
+  }
+
   return shells
 }
 
@@ -225,6 +234,8 @@ export function launch(
       return spawn(foundShell.path, ['--working-directory=' + path])
     case Shell.Warp:
       return spawn(foundShell.path, [], { cwd: path })
+    case Shell.Ptyxis:
+      return spawn(foundShell.path, ['--new-window', '--working-directory=' + path])
     default:
       return assertNever(shell, `Unknown shell: ${shell}`)
   }

--- a/docs/technical/shell-integration.md
+++ b/docs/technical/shell-integration.md
@@ -242,6 +242,7 @@ These shells are currently supported:
  - [XTerm](http://invisible-island.net/xterm/)
  - [Terminology](https://www.enlightenment.org/docs/apps/terminology.md)
  - [Black Box](https://gitlab.gnome.org/raggesilver/blackbox)
+ - [Ptyxis](https://gitlab.gnome.org/chergert/ptyxis)
 
 These are defined in an enum at the top of the file:
 
@@ -256,6 +257,7 @@ export enum Shell {
   Xterm = 'XTerm',
   Terminology = 'Terminology',
   BlackBox = 'Black Box',
+  Ptyxis = 'Ptyxis',
 }
 ```
 


### PR DESCRIPTION

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- Adds support for the [Ptyxis](https://gitlab.gnome.org/chergert/ptyxis) terminal on Linux.
- Ptyxis is being installed by default on Fedora 41 Workstation beta.
- The flatpak isn't supported, just the native binary from e.g. Fedora's repos.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: Added support for the Ptyxis terminal

