### PR TITLE
bump tags to new version of packaging scripts

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -26,7 +26,7 @@ jobs:
           ref: ${{ inputs.ref }}
           submodules: recursive
       - name: Package and test application in container
-        uses: shiftkey/desktop-ubuntu-arm64-packaging@d5a0346959c7d553eb8dbe2828e7fe2e10147160
+        uses: shiftkey/desktop-ubuntu-arm64-packaging@9be09c4b945873e6509baaf690d457aae08cf901
       - name: Upload output artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -48,7 +48,7 @@ jobs:
           ref: ${{ inputs.ref }}
           submodules: recursive
       - name: Package and test application in container
-        uses: shiftkey/desktop-ubuntu-arm-packaging@48215eee48762e1c919309b2915b8ceb478e5642
+        uses: shiftkey/desktop-ubuntu-arm-packaging@dd75ebc57f69fdb9319ab2b0fe11b253bb1ff2a4
       - name: Upload output artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -70,7 +70,7 @@ jobs:
           ref: ${{ inputs.ref }}
           submodules: recursive
       - name: Package and test application in container
-        uses: shiftkey/desktop-ubuntu-amd64-packaging@33a71a92b43e54694726382d1e4029a91fe894cc
+        uses: shiftkey/desktop-ubuntu-amd64-packaging@ea7b7a6a940a6b907b160b946439c5c7a516f9f1
       - name: Upload output artifacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Reviewing if this fixes our CI issue to confirm tests are running correct on Linux


 - [x] CI passes
 - [x] poke at `git` internals and see what version was present here