### PR TITLE
shells: add Ptyxis terminal

### DIFF
--- a/app/src/lib/shells/linux.ts
+++ b/app/src/lib/shells/linux.ts
@@ -28,6 +28,7 @@ export enum Shell {
   LXTerminal = 'LXDE Terminal',
   Warp = 'Warp',
   BlackBox = 'Black Box',
+  Ptyxis = 'Ptyxis',
 }
 
 export const Default = Shell.Gnome
@@ -76,6 +77,8 @@ function getShellPath(shell: Shell): Promise<string | null> {
       return getPathIfAvailable('/usr/bin/warp-terminal')
     case Shell.BlackBox:
       return getPathIfAvailable('/usr/bin/blackbox-terminal')
+    case Shell.Ptyxis:
+      return getPathIfAvailable('/usr/bin/ptyxis')
     default:
       return assertNever(shell, `Unknown shell: ${shell}`)
   }
@@ -102,6 +105,7 @@ export async function getAvailableShells(): Promise<
     lxterminalPath,
     warpPath,
     blackBoxPath,
+    ptyxisPath,
   ] = await Promise.all([
     getShellPath(Shell.Gnome),
     getShellPath(Shell.GnomeConsole),
@@ -120,6 +124,7 @@ export async function getAvailableShells(): Promise<
     getShellPath(Shell.LXTerminal),
     getShellPath(Shell.Warp),
     getShellPath(Shell.BlackBox),
+    getShellPath(Shell.Ptyxis),
   ])
 
   const shells: Array<FoundShell<Shell>> = []
@@ -191,6 +196,10 @@ export async function getAvailableShells(): Promise<
     shells.push({ shell: Shell.BlackBox, path: blackBoxPath })
   }
 
+  if (ptyxisPath) {
+    shells.push({ shell: Shell.Ptyxis, path: ptyxisPath })
+  }
+
   return shells
 }
 
@@ -227,6 +236,11 @@ export function launch(
       return spawn(foundShell.path, ['--working-directory=' + path])
     case Shell.Warp:
       return spawn(foundShell.path, [], { cwd: path })
+    case Shell.Ptyxis:
+      return spawn(foundShell.path, [
+        '--new-window',
+        '--working-directory=' + path,
+      ])
     default:
       return assertNever(shell, `Unknown shell: ${shell}`)
   }

--- a/docs/technical/shell-integration.md
+++ b/docs/technical/shell-integration.md
@@ -242,6 +242,7 @@ These shells are currently supported:
  - [XTerm](http://invisible-island.net/xterm/)
  - [Terminology](https://www.enlightenment.org/docs/apps/terminology.md)
  - [Black Box](https://gitlab.gnome.org/raggesilver/blackbox)
+ - [Ptyxis](https://gitlab.gnome.org/chergert/ptyxis)
 
 These are defined in an enum at the top of the file:
 
@@ -256,6 +257,7 @@ export enum Shell {
   Xterm = 'XTerm',
   Terminology = 'Terminology',
   BlackBox = 'Black Box',
+  Ptyxis = 'Ptyxis',
 }
 ```
 


### PR DESCRIPTION
## Description

- Adds support for the [Ptyxis](https://gitlab.gnome.org/chergert/ptyxis) terminal on Linux.
- Detects the native executable at `/usr/bin/ptyxis` and opens a new window in the selected repository.
- Works when GitHub Desktop is packaged as a Flatpak and Ptyxis is installed on the host through the existing `flatpak-spawn` integration.
- [Ubuntu 26.04 LTS](https://documentation.ubuntu.com/release-notes/26.04/summary-for-lts-users/#new-terminal-emulator) now provides its default Terminal app through Ptyxis instead of GNOME Terminal.
- Revives #1131, which was closed after its contributor deleted the repository containing the head branch, and preserves credit for the original implementation.

### Screenshots

On Ubuntu 26.04, GitHub Desktop retains an unavailable **Open in GNOME Console** entry:

![GitHub Desktop showing a stale Open in GNOME Console menu item on Ubuntu 26.04](https://raw.githubusercontent.com/khengyun/desktop/pr-assets/.github/pr-assets/1309/ubuntu-26-stale-gnome-console-menu.png)

Selecting the entry throws `Cannot read properties of undefined (reading path)` instead of opening a terminal:

![GitHub Desktop undefined path error after selecting GNOME Console on Ubuntu 26.04](https://raw.githubusercontent.com/khengyun/desktop/pr-assets/.github/pr-assets/1309/ubuntu-26-undefined-path-error.png)

## Testing

- `yarn lint`
- `yarn compile:dev`
- Manually launched Ptyxis 50.1 from the GitHub Desktop Flatpak sandbox with the repository as its working directory.
- `yarn test`: 1,030 passed and 4 skipped; 2 unrelated existing tests failed locally with Git 2.53.0 because a non-repository directory now returns a fatal error (`remote-test.ts` and `for-each-ref-test.ts`).

## Release notes

Notes: Added support for the Ptyxis terminal